### PR TITLE
feat: keep markdown notes alongside each session

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ needs you.
   keymap is fully rebindable and persisted.
 - **Session icons.** Assign custom icons to your sessions to quickly identify
   them at a glance in the sidebar.
+- **Session notes.** A markdown scratchpad docked beside each session, with
+  tickable checklists. Notes live with the session and go when it does.
 - **Launchers.** Save the commands you start often (e.g. an AI agent) and pick a
   default. Launchers support session variables (like `__SESSION_DIR__`) and can
   run with or without a login shell.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,12 +18,14 @@ import { DaemonSkewDialog } from "@/components/DaemonSkewDialog";
 import { ShortcutsDialog } from "@/components/ShortcutsDialog";
 import { SessionSettingsDialog } from "@/components/SessionSettingsDialog";
 import { SessionUsageDialog } from "@/components/SessionUsageDialog";
+import { SessionNotesPanel } from "@/components/SessionNotesPanel";
 import { AddIconDialog } from "@/components/AddIconDialog";
 import { Toaster } from "@/components/ui/sonner";
 import { hydrateSessions, startPersistence, flushSessions } from "@/lib/persistence";
 import { checkDaemon, daemonOptedOut } from "@/lib/pty";
 import { hydrateLaunchers, startLauncherPersistence, flushLaunchers } from "@/store/launchers";
 import { hydrateKeybindings, startKeybindingPersistence, flushKeybindings } from "@/store/keybindings";
+import { hydrateNotes, startNotePersistence, flushNotes } from "@/store/notes";
 import { startIconSync } from "@/store/icons";
 import { refreshSessionGit } from "@/lib/launch";
 import { useGlobalShortcuts } from "@/lib/useGlobalShortcuts";
@@ -109,6 +111,7 @@ export default function App() {
         flushSessions(),
         flushLaunchers(),
         flushKeybindings(),
+        flushNotes(),
       ]);
     });
     return () => void unlisten.then((f) => f());
@@ -150,6 +153,15 @@ export default function App() {
     let unsubscribe = () => {};
     hydrateKeybindings().finally(() => {
       unsubscribe = startKeybindingPersistence();
+    });
+    return () => unsubscribe();
+  }, []);
+
+  // Restore + persist session notes.
+  useEffect(() => {
+    let unsubscribe = () => {};
+    hydrateNotes().finally(() => {
+      unsubscribe = startNotePersistence();
     });
     return () => unsubscribe();
   }, []);
@@ -227,6 +239,7 @@ export default function App() {
       <ShortcutsDialog />
       <SessionSettingsDialog />
       <SessionUsageDialog />
+      <SessionNotesPanel />
       <AddIconDialog />
       <AppProfileDialog />
       <Toaster />

--- a/src/components/SessionNotesPanel.tsx
+++ b/src/components/SessionNotesPanel.tsx
@@ -1,0 +1,396 @@
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { Pencil, Check } from "lucide-react";
+import { cn } from "@/lib/utils";
+import {
+  Dialog,
+  DialogPanel,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { ActionTooltip } from "./ActionTooltip";
+import { isMac } from "@/lib/platform";
+import { openUrl } from "@/lib/pty";
+import { useUI } from "@/store/ui";
+import { useSessions } from "@/store/sessions";
+import { useNotes } from "@/store/notes";
+import {
+  parseBlocks,
+  parseInline,
+  toggleTask,
+  continueList,
+  type Span,
+} from "@/lib/markdown";
+
+// The panel's own keys, so they aren't part of the rebindable global keymap.
+const EDIT_KEYS = isMac ? "⌘⏎" : "Ctrl+Enter";
+const SAVE_KEYS = isMac ? "⌘S" : "Ctrl+S";
+
+export function SessionNotesPanel() {
+  const sessionId = useUI((s) => s.sessionNotes);
+  const close = useUI((s) => s.closeSessionNotes);
+  const session = useSessions((s) => s.sessions.find((x) => x.id === sessionId));
+  const text = useNotes((s) => (sessionId ? (s.notes[sessionId] ?? "") : ""));
+  const setNote = useNotes((s) => s.setNote);
+  const [editing, setEditing] = useState(false);
+  const editor = useRef<HTMLTextAreaElement>(null);
+  const view = useRef<HTMLDivElement>(null);
+  const panel = useRef<HTMLDivElement>(null);
+  // Where the caret goes once a rewritten note has been committed to the DOM.
+  const caret = useRef<number | null>(null);
+
+  // Open straight into the editor when there is nothing to render yet, and
+  // leave the editor when the panel moves to another session.
+  useEffect(() => {
+    if (!sessionId) return;
+    setEditing(!useNotes.getState().notes[sessionId]);
+  }, [sessionId]);
+
+  // The panel belongs to one session, so navigating away would leave it stale:
+  // close it. Keyed on the change, so opening it for a session that isn't the
+  // active one still works.
+  useEffect(() => {
+    if (!sessionId) return;
+    return useSessions.subscribe((s, prevState) => {
+      if (
+        s.activeSessionId !== prevState.activeSessionId &&
+        s.activeSessionId !== sessionId
+      ) {
+        close();
+      }
+    });
+  }, [sessionId, close]);
+
+  // A note holding nothing but the blank lines someone typed and abandoned is
+  // not worth keeping; prune it once the panel leaves that session.
+  useEffect(() => {
+    if (!sessionId) return;
+    return () => {
+      const { notes, removeNote } = useNotes.getState();
+      if (notes[sessionId] !== undefined && !notes[sessionId].trim()) {
+        removeNote(sessionId);
+      }
+    };
+  }, [sessionId]);
+
+  // Take focus when the panel appears (and when it leaves the editor) so its
+  // own keys work right away and the notes scroll with the keyboard. The
+  // editor focuses itself on mount, so this only covers the rendered view.
+  useEffect(() => {
+    if (sessionId && !editing) view.current?.focus();
+  }, [sessionId, editing]);
+
+  // Esc, on the window in the capture phase, ahead of the dismissable layers.
+  // Radix would otherwise decide this: a menu that has just closed can still
+  // swallow the key, and either way Esc in the editor has to mean "leave the
+  // editor", not "close the panel". Only while the focus is inside the panel,
+  // so a terminal that wants Esc keeps getting it.
+  useEffect(() => {
+    if (!sessionId) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== "Escape") return;
+      if (!panel.current?.contains(document.activeElement)) return;
+      e.preventDefault();
+      e.stopPropagation();
+      if (editor.current && useNotes.getState().notes[sessionId]?.trim()) {
+        setEditing(false);
+      } else close();
+    };
+    window.addEventListener("keydown", onKey, true);
+    return () => window.removeEventListener("keydown", onKey, true);
+  }, [sessionId, close]);
+
+  // Typing writes straight through to the store (debounced to disk), so
+  // "Done" only switches to the rendered view and nothing is ever lost by
+  // closing the panel mid-edit.
+  const edit = (value: string) => sessionId && setNote(sessionId, value);
+
+  // Enter inside a list continues it, like GitHub's own editor. Rewriting the
+  // value by hand loses the browser's undo entry for that keystroke, which is
+  // the usual trade for this behaviour in a plain textarea.
+  const onEditorKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    const el = e.currentTarget;
+    if (e.key === "s" && (e.metaKey || e.ctrlKey)) {
+      e.preventDefault();
+      setEditing(false);
+      return;
+    }
+    if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+      e.preventDefault();
+      setEditing(false);
+      return;
+    }
+    if (e.key !== "Enter" || e.shiftKey || el.selectionStart !== el.selectionEnd) {
+      return;
+    }
+    const next = continueList(el.value, el.selectionStart);
+    if (!next) return;
+    e.preventDefault();
+    caret.current = next.caret;
+    edit(next.value);
+  };
+
+  // The value goes through the store, so the caret can only be placed once the
+  // new text is in the DOM. Before paint, not in a frame callback: a keystroke
+  // landing between the two would be inserted at the stale caret.
+  useLayoutEffect(() => {
+    if (caret.current === null) return;
+    editor.current?.setSelectionRange(caret.current, caret.current);
+    caret.current = null;
+  });
+
+  return (
+    <Dialog open={!!sessionId} modal={false} onOpenChange={(o) => !o && close()}>
+      <DialogPanel
+        ref={panel}
+        className="w-[560px]"
+        onInteractOutside={(e) => e.preventDefault()}
+        // Esc is handled by the panel itself (see the listener above), so the
+        // dismissable layer never acts on it.
+        onEscapeKeyDown={(e) => e.preventDefault()}
+        // Focus the notes themselves rather than letting the focus scope land
+        // on the close button, so the panel's keys work as soon as it appears.
+        onOpenAutoFocus={(e) => {
+          e.preventDefault();
+          (editor.current ?? view.current)?.focus();
+        }}
+      >
+        <div className="border-b border-border px-4 py-3 pr-10">
+          <DialogTitle>Notes</DialogTitle>
+          <DialogDescription>
+            {session?.name ?? "Session"} · GitHub-flavored markdown
+          </DialogDescription>
+        </div>
+
+        {editing ? (
+          <textarea
+            ref={editor}
+            autoFocus
+            value={text}
+            onChange={(e) => edit(e.target.value)}
+            onKeyDown={onEditorKeyDown}
+            placeholder={"# Plan\n\n- [ ] first step\n- [x] done step"}
+            spellCheck={false}
+            className="flex-1 resize-none bg-transparent px-4 py-3 font-mono text-xs leading-relaxed outline-none placeholder:text-muted-foreground"
+          />
+        ) : (
+          <div
+            ref={view}
+            tabIndex={-1}
+            onDoubleClick={() => setEditing(true)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+                e.preventDefault();
+                setEditing(true);
+              }
+            }}
+            title="Double-click to edit"
+            className="flex-1 overflow-y-auto px-4 py-3 text-sm outline-none"
+          >
+            <Rendered
+              source={text}
+              onToggle={(line) => edit(toggleTask(text, line))}
+            />
+          </div>
+        )}
+
+        <div className="flex items-center justify-end border-t border-border px-4 py-2">
+          <ActionTooltip label={editing ? `Save (${SAVE_KEYS})` : `Edit (${EDIT_KEYS})`}>
+            <Button
+              variant={editing ? "default" : "ghost"}
+              size="sm"
+              onClick={() => setEditing((v) => !v)}
+            >
+              {editing ? (
+                <>
+                  <Check className="size-4" /> Save
+                </>
+              ) : (
+                <>
+                  <Pencil className="size-4" /> Edit
+                </>
+              )}
+            </Button>
+          </ActionTooltip>
+        </div>
+      </DialogPanel>
+    </Dialog>
+  );
+}
+
+function Rendered({
+  source,
+  onToggle,
+}: {
+  source: string;
+  onToggle: (line: number) => void;
+}) {
+  const blocks = parseBlocks(source);
+  if (blocks.length === 0) {
+    return <p className="text-muted-foreground">No notes yet.</p>;
+  }
+  return (
+    <div className="space-y-2">
+      {blocks.map((b, i) => {
+        switch (b.t) {
+          case "h":
+            return (
+              <p
+                key={i}
+                className={cn(
+                  "font-semibold",
+                  b.level === 1 && "text-base",
+                  b.level >= 3 && "text-xs uppercase tracking-wide",
+                )}
+              >
+                <Inline spans={parseInline(b.text)} />
+              </p>
+            );
+          case "hr":
+            return <hr key={i} className="border-border" />;
+          case "code":
+            return (
+              <pre
+                key={i}
+                className="overflow-x-auto rounded-md bg-muted p-2 font-mono text-xs"
+              >
+                {b.text}
+              </pre>
+            );
+          case "quote":
+            return (
+              <p
+                key={i}
+                className="whitespace-pre-wrap border-l-2 border-border pl-3 text-muted-foreground"
+              >
+                <Inline spans={parseInline(b.text)} />
+              </p>
+            );
+          case "table":
+            return (
+              <div key={i} className="overflow-x-auto">
+                <table className="w-full border-collapse text-left">
+                  <thead>
+                    <tr>
+                      {b.header.map((h, c) => (
+                        <th
+                          key={c}
+                          style={{ textAlign: b.align[c] ?? undefined }}
+                          className="border-b border-border px-2 py-1 font-semibold"
+                        >
+                          <Inline spans={parseInline(h)} />
+                        </th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {b.rows.map((row, r) => (
+                      <tr key={r}>
+                        {row.map((cell, c) => (
+                          <td
+                            key={c}
+                            style={{ textAlign: b.align[c] ?? undefined }}
+                            className="border-b border-border/50 px-2 py-1"
+                          >
+                            <Inline spans={parseInline(cell)} />
+                          </td>
+                        ))}
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            );
+          case "list":
+            return (
+              <ul key={i} className="space-y-1">
+                {b.items.map((item, n) => (
+                  <li
+                    key={item.line}
+                    style={{ paddingLeft: `${item.indent * 16}px` }}
+                    className="flex items-start gap-2"
+                  >
+                    {item.task ? (
+                      <input
+                        type="checkbox"
+                        checked={item.done}
+                        onChange={() => onToggle(item.line)}
+                        className="mt-1 size-3.5 shrink-0 accent-emerald-500"
+                      />
+                    ) : (
+                      <span className="mt-px shrink-0 text-muted-foreground">
+                        {b.ordered ? `${b.start + n}.` : "•"}
+                      </span>
+                    )}
+                    <span
+                      className={cn(
+                        "min-w-0 flex-1",
+                        item.done && "text-muted-foreground line-through",
+                      )}
+                    >
+                      <Inline spans={parseInline(item.text)} />
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            );
+          default:
+            return (
+              <p key={i} className="whitespace-pre-wrap">
+                <Inline spans={parseInline(b.text)} />
+              </p>
+            );
+        }
+      })}
+    </div>
+  );
+}
+
+function Inline({ spans }: { spans: Span[] }) {
+  return (
+    <>
+      {spans.map((s, i) => {
+        switch (s.t) {
+          case "code":
+            return (
+              <code key={i} className="rounded bg-muted px-1 font-mono text-xs">
+                {s.v}
+              </code>
+            );
+          case "strong":
+            return (
+              <strong key={i} className="font-semibold">
+                {s.v}
+              </strong>
+            );
+          case "em":
+            return <em key={i}>{s.v}</em>;
+          case "del":
+            return (
+              <span key={i} className="line-through">
+                {s.v}
+              </span>
+            );
+          case "link":
+            return (
+              // Handed to the OS browser: there is nowhere for the webview to
+              // navigate to, and letting it try would strand the app window.
+              <a
+                key={i}
+                href={s.href}
+                onClick={(e) => {
+                  e.preventDefault();
+                  void openUrl(s.href);
+                }}
+                className="text-blue-400 underline underline-offset-2"
+              >
+                {s.v}
+              </a>
+            );
+          default:
+            return <span key={i}>{s.v}</span>;
+        }
+      })}
+    </>
+  );
+}

--- a/src/components/SessionSidebar.tsx
+++ b/src/components/SessionSidebar.tsx
@@ -440,6 +440,7 @@ function SessionRow({
 }) {
   const openSessionSettings = useUI((s) => s.openSessionSettings);
   const openSessionUsage = useUI((s) => s.openSessionUsage);
+  const openSessionNotes = useUI((s) => s.openSessionNotes);
   return (
     <ContextMenu onOpenChange={onMenuOpenChange}>
       <ContextMenuTrigger asChild>
@@ -516,7 +517,11 @@ function SessionRow({
       </ActionTooltip>
     </div>
       </ContextMenuTrigger>
-      <ContextMenuContent>
+      {/* Every item here opens something that takes focus itself. The menu
+          restores focus to this row when it finishes unmounting, which lands
+          a few hundred ms later and would pull focus back out of whatever
+          just opened. */}
+      <ContextMenuContent onCloseAutoFocus={(e) => e.preventDefault()}>
         {/* Both items open a dialog; defer past the menu's own close so its
             exit animation doesn't race the dialog's pointer-events lock. */}
         <ContextMenuItem
@@ -524,6 +529,17 @@ function SessionRow({
         >
           Settings
           <ContextMenuShortcut>{shortcutLabel("session-settings")}</ContextMenuShortcut>
+        </ContextMenuItem>
+        <ContextMenuItem
+          onSelect={() =>
+            setTimeout(() => {
+              onSelect();
+              openSessionNotes(session.id);
+            }, 0)
+          }
+        >
+          Notes
+          <ContextMenuShortcut>{shortcutLabel("session-notes")}</ContextMenuShortcut>
         </ContextMenuItem>
         <ContextMenuItem
           onSelect={() =>

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -184,6 +184,17 @@ export function toggleActiveSessionUsage() {
   if (activeSessionId) ui.openSessionUsage(activeSessionId);
 }
 
+/** Toggle the notes panel for the active session (same reasoning as usage). */
+export function toggleActiveSessionNotes() {
+  const ui = useUI.getState();
+  if (ui.sessionNotes) {
+    ui.closeSessionNotes();
+    return;
+  }
+  const { activeSessionId } = useSessions.getState();
+  if (activeSessionId) ui.openSessionNotes(activeSessionId);
+}
+
 /** Start renaming the active terminal's tab label. */
 export function renameActiveTerminal() {
   const id = activeTerminalId();

--- a/src/lib/keymap.ts
+++ b/src/lib/keymap.ts
@@ -12,6 +12,7 @@ import {
   renameActiveTerminal,
   openActiveSessionSettings,
   toggleActiveSessionUsage,
+  toggleActiveSessionNotes,
   moveTerminalToPane,
   closeActiveSession,
 } from "@/lib/actions";
@@ -346,6 +347,16 @@ export const SHORTCUTS: Shortcut[] = [
       { code: "KeyR", ctrl: true, shift: true },
     ),
     run: () => toggleActiveSessionUsage(),
+  },
+  {
+    id: "session-notes",
+    description: "Session notes",
+    // N for notes; plain Cmd/Ctrl+Shift+N is already New session on Linux.
+    defaultCombo: def(
+      { code: "KeyN", meta: true, alt: true },
+      { code: "KeyN", ctrl: true, alt: true },
+    ),
+    run: () => toggleActiveSessionNotes(),
   },
   {
     id: "help",

--- a/src/lib/markdown.test.ts
+++ b/src/lib/markdown.test.ts
@@ -1,0 +1,160 @@
+import { test, expect, describe } from "vitest";
+import { parseBlocks, parseInline, toggleTask, continueList } from "./markdown";
+
+describe("parseBlocks", () => {
+  test("headings, rules and paragraphs", () => {
+    expect(parseBlocks("## Plan\n\ntwo\nlines\n\n---")).toEqual([
+      { t: "h", level: 2, text: "Plan" },
+      { t: "p", text: "two\nlines" },
+      { t: "hr" },
+    ]);
+  });
+
+  test("task items carry their state and source line", () => {
+    const [list] = parseBlocks("- [ ] todo\n- [x] done\n  - plain");
+    expect(list).toEqual({
+      t: "list",
+      ordered: false,
+      start: 1,
+      items: [
+        { text: "todo", indent: 0, line: 0, task: true, done: false },
+        { text: "done", indent: 0, line: 1, task: true, done: true },
+        { text: "plain", indent: 1, line: 2, task: false, done: false },
+      ],
+    });
+  });
+
+  test("an ordered list is its own block", () => {
+    const blocks = parseBlocks("- a\n1. b");
+    expect(blocks.map((b) => b.t === "list" && b.ordered)).toEqual([false, true]);
+  });
+
+  test("an ordered list keeps the number it starts from", () => {
+    const [list] = parseBlocks("3. three\n4. four");
+    expect(list.t === "list" && list.start).toBe(3);
+  });
+
+  test("fenced code keeps its lines verbatim", () => {
+    expect(parseBlocks("```\n- not a list\n```")).toEqual([
+      { t: "code", text: "- not a list" },
+    ]);
+  });
+
+  test("an unterminated fence does not loop forever", () => {
+    expect(parseBlocks("```\nstill open")).toEqual([
+      { t: "code", text: "still open" },
+    ]);
+  });
+
+  test("quote lines fold into one block", () => {
+    expect(parseBlocks("> one\n> two")).toEqual([
+      { t: "quote", text: "one\ntwo" },
+    ]);
+  });
+
+  test("a table takes its alignment from the delimiter row", () => {
+    expect(parseBlocks("| a | b |\n| :-- | --: |\n| 1 | 2 |")).toEqual([
+      {
+        t: "table",
+        header: ["a", "b"],
+        align: ["left", "right"],
+        rows: [["1", "2"]],
+      },
+    ]);
+  });
+
+  test("a pipe without a delimiter row is just a paragraph", () => {
+    expect(parseBlocks("a | b")).toEqual([{ t: "p", text: "a | b" }]);
+  });
+});
+
+describe("parseInline", () => {
+  test("code, emphasis and links", () => {
+    expect(parseInline("run `ls` **now** [docs](https://a.b)")).toEqual([
+      { t: "text", v: "run " },
+      { t: "code", v: "ls" },
+      { t: "text", v: " " },
+      { t: "strong", v: "now" },
+      { t: "text", v: " " },
+      { t: "link", v: "docs", href: "https://a.b" },
+    ]);
+  });
+
+  test("bare URLs autolink, without the trailing period", () => {
+    expect(parseInline("see https://a.b/c.")).toEqual([
+      { t: "text", v: "see " },
+      { t: "link", v: "https://a.b/c", href: "https://a.b/c" },
+      { t: "text", v: "." },
+    ]);
+    expect(parseInline("www.a.b")).toEqual([
+      { t: "link", v: "www.a.b", href: "https://www.a.b" },
+    ]);
+  });
+
+  test("underscores inside a word are left alone", () => {
+    expect(parseInline("snake_case_name")).toEqual([
+      { t: "text", v: "snake_case_name" },
+    ]);
+    expect(parseInline("_yes_")).toEqual([{ t: "em", v: "yes" }]);
+  });
+
+  test("a space inside the delimiters keeps the text literal", () => {
+    // Shell globs and arithmetic are ordinary things to jot in a note.
+    expect(parseInline("rm *.log and *.tmp")).toEqual([
+      { t: "text", v: "rm *.log and *.tmp" },
+    ]);
+    expect(parseInline("2 * 3 * 4")).toEqual([{ t: "text", v: "2 * 3 * 4" }]);
+    expect(parseInline("*em*")).toEqual([{ t: "em", v: "em" }]);
+    expect(parseInline("**bold**")).toEqual([{ t: "strong", v: "bold" }]);
+  });
+
+  test("a script URL never becomes a link", () => {
+    const spans = parseInline("[x](javascript:alert(1)) [y](data:text/html,x)");
+    expect(spans.every((s) => s.t === "text")).toBe(true);
+  });
+});
+
+describe("continueList", () => {
+  test("a task item continues with an unticked box", () => {
+    const src = "- [x] done";
+    expect(continueList(src, src.length)).toEqual({
+      value: "- [x] done\n- [ ] ",
+      caret: 17,
+    });
+  });
+
+  test("an ordered item continues with the next number", () => {
+    const src = "  2. two";
+    expect(continueList(src, src.length)?.value).toBe("  2. two\n  3. ");
+  });
+
+  test("an empty item ends the list", () => {
+    const src = "- [ ] a\n- [ ] ";
+    expect(continueList(src, src.length)).toEqual({
+      value: "- [ ] a\n",
+      caret: 8,
+    });
+  });
+
+  test("outside a list Enter is left alone", () => {
+    expect(continueList("plain text", 4)).toBeNull();
+  });
+
+  test("Enter at the start of an item opens a line above it", () => {
+    expect(continueList("- a", 0)).toBeNull();
+    expect(continueList("- [ ] a", 3)).toBeNull();
+  });
+});
+
+describe("toggleTask", () => {
+  test("flips only the given line", () => {
+    const src = "- [ ] a\n- [x] b";
+    expect(toggleTask(src, 0)).toBe("- [x] a\n- [x] b");
+    expect(toggleTask(src, 1)).toBe("- [ ] a\n- [ ] b");
+  });
+
+  test("leaves non-task lines alone", () => {
+    expect(toggleTask("- plain", 0)).toBe("- plain");
+    expect(toggleTask("- [ ] a", 9)).toBe("- [ ] a");
+  });
+});

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -1,0 +1,298 @@
+/**
+ * GitHub Flavored Markdown for session notes: headings, lists with task
+ * checkboxes, tables, fenced code, quotes, rules, paragraphs, and inline spans
+ * including strikethrough and bare-URL autolinks. Parsing only; the notes panel
+ * turns these into React nodes, so nothing is ever fed to innerHTML.
+ *
+ * ponytail: hand-rolled instead of a markdown dependency, which would also drag
+ * in a sanitizer. Left out of GFM: nested emphasis, reference links, footnotes,
+ * inline HTML, and setext headings. Reach for `marked` plus DOMPurify if notes
+ * ever need those.
+ */
+
+export type Span =
+  | { t: "text"; v: string }
+  | { t: "code"; v: string }
+  | { t: "strong"; v: string }
+  | { t: "em"; v: string }
+  | { t: "del"; v: string }
+  | { t: "link"; v: string; href: string };
+
+export interface ListItem {
+  text: string;
+  indent: number;
+  // Source line, so clicking a checkbox can rewrite exactly that line.
+  line: number;
+  task: boolean;
+  done: boolean;
+}
+
+export type Align = "left" | "center" | "right";
+
+export type Block =
+  | { t: "h"; level: number; text: string }
+  | { t: "p"; text: string }
+  | { t: "code"; text: string }
+  | { t: "quote"; text: string }
+  | { t: "hr" }
+  // `start` is the first item's number, so a list written from 3. renders from 3.
+  | { t: "list"; ordered: boolean; start: number; items: ListItem[] }
+  | { t: "table"; header: string[]; align: (Align | null)[]; rows: string[][] };
+
+// GFM's flanking rule, spelled as "no space just inside the delimiters" so a
+// line like `rm *.log and *.tmp` or `2 * 3 * 4` stays literal. Written without
+// lookbehind, which older WebKitGTK builds don't have.
+const between = (inner: string) => `(\\S|\\S${inner}*?\\S)`;
+
+const INLINE = new RegExp(
+  [
+    "`([^`]+)`", // code
+    `\\*\\*${between("[^\\n]")}\\*\\*`, // **strong**
+    `__${between("[^\\n]")}__`, // __strong__
+    `\\*${between("[^*\\n]")}\\*`, // *em*
+    `_${between("[^_\\n]")}_`, // _em_
+    `~~${between("[^\\n]")}~~`, // ~~del~~
+    "\\[([^\\]\\n]*)\\]\\(([^)\\s]+)\\)", // [text](href)
+    "(https?://[^\\s<]+|www\\.[^\\s<]+)", // bare URL
+  ].join("|"),
+  "g",
+);
+
+// Rendered as <a href>, so anything that could execute (javascript:, data:) is
+// left as plain text instead.
+const SAFE_HREF = /^(https?:\/\/|mailto:)/i;
+
+// GFM leaves intraword underscores alone, so snake_case_names survive.
+const isWordChar = (c: string | undefined) => !!c && /\w/.test(c);
+
+// Trailing sentence punctuation belongs to the sentence, not to the URL.
+const TRAILING = /[.,;:!?)\]]+$/;
+
+export function parseInline(src: string): Span[] {
+  const out: Span[] = [];
+  let last = 0;
+  // Merges into the previous run, so a stretch that only looked like markup
+  // (an intraword underscore) comes back as one span.
+  const text = (v: string) => {
+    if (!v) return;
+    const prev = out[out.length - 1];
+    if (prev?.t === "text") prev.v += v;
+    else out.push({ t: "text", v });
+  };
+
+  for (const m of src.matchAll(INLINE)) {
+    const at = m.index ?? 0;
+    const [whole, code, strongStar, strongUnder, emStar, emUnder, del, label, href, url] =
+      m;
+    text(src.slice(last, at));
+    last = at + whole.length;
+
+    if (code !== undefined) out.push({ t: "code", v: code });
+    else if (strongStar !== undefined) out.push({ t: "strong", v: strongStar });
+    else if (emStar !== undefined) out.push({ t: "em", v: emStar });
+    else if (del !== undefined) out.push({ t: "del", v: del });
+    else if (strongUnder !== undefined || emUnder !== undefined) {
+      if (isWordChar(src[at - 1]) || isWordChar(src[last])) text(whole);
+      else if (strongUnder !== undefined) out.push({ t: "strong", v: strongUnder });
+      else out.push({ t: "em", v: emUnder });
+    } else if (url !== undefined) {
+      const trimmed = url.replace(TRAILING, "");
+      out.push({
+        t: "link",
+        v: trimmed,
+        href: trimmed.startsWith("www.") ? `https://${trimmed}` : trimmed,
+      });
+      text(url.slice(trimmed.length));
+    } else if (SAFE_HREF.test(href)) {
+      out.push({ t: "link", v: label || href, href });
+    } else text(whole);
+  }
+
+  text(src.slice(last));
+  return out;
+}
+
+const FENCE = /^\s*```/;
+const HEADING = /^(#{1,6})\s+(.*)$/;
+const RULE = /^\s*(-{3,}|\*{3,}|_{3,})\s*$/;
+const BULLET = /^(\s*)[-*+]\s+(.*)$/;
+const NUMBER = /^(\s*)\d+[.)]\s+(.*)$/;
+const TASK = /^\[([ xX])\]\s*(.*)$/;
+const QUOTE = /^\s*>\s?(.*)$/;
+
+const DELIMITER = /^\s*\|?(\s*:?-+:?\s*\|)+\s*:?-+:?\s*\|?\s*$/;
+
+const itemMatch = (line: string) => BULLET.exec(line) ?? NUMBER.exec(line);
+
+const cells = (line: string) =>
+  line
+    .trim()
+    .replace(/^\||\|$/g, "")
+    .split("|")
+    .map((c) => c.trim());
+
+const alignOf = (spec: string): Align | null => {
+  const s = spec.trim();
+  if (s.startsWith(":") && s.endsWith(":")) return "center";
+  if (s.endsWith(":")) return "right";
+  if (s.startsWith(":")) return "left";
+  return null;
+};
+
+export function parseBlocks(src: string): Block[] {
+  const lines = src.split("\n");
+  const blocks: Block[] = [];
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i];
+
+    if (FENCE.test(line)) {
+      const body: string[] = [];
+      i++;
+      while (i < lines.length && !FENCE.test(lines[i])) body.push(lines[i++]);
+      i++; // closing fence, or past the end for an unterminated block
+      blocks.push({ t: "code", text: body.join("\n") });
+      continue;
+    }
+
+    if (!line.trim()) {
+      i++;
+      continue;
+    }
+
+    const h = HEADING.exec(line);
+    if (h) {
+      blocks.push({ t: "h", level: h[1].length, text: h[2] });
+      i++;
+      continue;
+    }
+
+    if (RULE.test(line)) {
+      blocks.push({ t: "hr" });
+      i++;
+      continue;
+    }
+
+    if (QUOTE.test(line)) {
+      const body: string[] = [];
+      while (i < lines.length) {
+        const q = QUOTE.exec(lines[i]);
+        if (!q) break;
+        body.push(q[1]);
+        i++;
+      }
+      blocks.push({ t: "quote", text: body.join("\n") });
+      continue;
+    }
+
+    // A table is a header row followed by a --- | :--: delimiter row.
+    if (line.includes("|") && DELIMITER.test(lines[i + 1] ?? "")) {
+      const header = cells(line);
+      const align = cells(lines[i + 1]).map(alignOf);
+      i += 2;
+      const rows: string[][] = [];
+      while (i < lines.length && lines[i].includes("|") && lines[i].trim()) {
+        rows.push(cells(lines[i++]));
+      }
+      blocks.push({ t: "table", header, align, rows });
+      continue;
+    }
+
+    if (itemMatch(line)) {
+      const ordered = !BULLET.test(line);
+      const start = ordered ? Number.parseInt(line.trim(), 10) || 1 : 1;
+      const items: ListItem[] = [];
+      while (i < lines.length) {
+        const m = itemMatch(lines[i]);
+        if (!m || !BULLET.test(lines[i]) !== ordered) break;
+        const task = TASK.exec(m[2]);
+        items.push({
+          text: task ? task[2] : m[2],
+          // Two spaces per level, the usual markdown convention.
+          indent: Math.floor(m[1].length / 2),
+          line: i,
+          task: !!task,
+          done: !!task && task[1].toLowerCase() === "x",
+        });
+        i++;
+      }
+      blocks.push({ t: "list", ordered, start, items });
+      continue;
+    }
+
+    const body: string[] = [];
+    while (
+      i < lines.length &&
+      lines[i].trim() &&
+      !FENCE.test(lines[i]) &&
+      !HEADING.test(lines[i]) &&
+      !RULE.test(lines[i]) &&
+      !QUOTE.test(lines[i]) &&
+      !itemMatch(lines[i]) &&
+      !(lines[i].includes("|") && DELIMITER.test(lines[i + 1] ?? ""))
+    ) {
+      body.push(lines[i++]);
+    }
+    blocks.push({ t: "p", text: body.join("\n") });
+  }
+
+  return blocks;
+}
+
+const ITEM_PREFIX = /^(\s*)([-*+]|\d+[.)])(\s+)(\[[ xX]\]\s*)?/;
+
+/**
+ * GitHub's editor behaviour for Enter inside a list: continue the list with a
+ * fresh marker (an unticked box under a task item), or drop the marker when the
+ * item is empty, which is how you end a list. Returns the rewritten note and
+ * the new caret, or null when the caret isn't in a list item and Enter should
+ * do its usual thing.
+ */
+export function continueList(
+  value: string,
+  caret: number,
+): { value: string; caret: number } | null {
+  const start = value.lastIndexOf("\n", caret - 1) + 1;
+  const end = value.indexOf("\n", caret) === -1 ? value.length : value.indexOf("\n", caret);
+  const line = value.slice(start, end);
+  const m = ITEM_PREFIX.exec(line);
+  if (!m) return null;
+
+  const [prefix, indent, marker, gap, box] = m;
+
+  // Caret still inside the marker (Enter at the start of an item opens a line
+  // above it), so there is no item to continue.
+  if (caret < start + prefix.length) return null;
+
+  // Nothing typed after the marker: clear the item instead of adding another.
+  if (!line.slice(prefix.length).trim()) {
+    return {
+      value: value.slice(0, start) + value.slice(end),
+      caret: start,
+    };
+  }
+
+  const next = /\d/.test(marker)
+    ? `${Number.parseInt(marker, 10) + 1}${marker.slice(-1)}`
+    : marker;
+  const insert = `\n${indent}${next}${gap}${box ? "[ ] " : ""}`;
+  return {
+    value: value.slice(0, caret) + insert + value.slice(caret),
+    caret: caret + insert.length,
+  };
+}
+
+/** Flip the checkbox on one source line, returning the rewritten note. */
+export function toggleTask(src: string, line: number): string {
+  const lines = src.split("\n");
+  const l = lines[line];
+  if (l === undefined) return src;
+  const next = l.replace(
+    /^(\s*(?:[-*+]|\d+[.)])\s+\[)([ xX])(\])/,
+    (_, open, mark, close) => `${open}${mark === " " ? "x" : " "}${close}`,
+  );
+  if (next === l) return src;
+  lines[line] = next;
+  return lines.join("\n");
+}

--- a/src/store/notes.ts
+++ b/src/store/notes.ts
@@ -1,0 +1,97 @@
+import { create } from "zustand";
+import { type Store } from "@tauri-apps/plugin-store";
+import { debouncedWriter } from "@/lib/persistDebounce";
+import { load } from "@/lib/storeFile";
+
+// Markdown notes, one per session, kept in thel's config dir. Sessions live in
+// per-profile layout files, but their ids are unique across profiles, so a
+// single notes file serves every window.
+interface NotesState {
+  notes: Record<string, string>;
+  setNote: (sessionId: string, text: string) => void;
+  /** Drop a session's notes (its session was closed). */
+  removeNote: (sessionId: string) => void;
+  hydrate: (notes: Record<string, string>) => void;
+}
+
+export const useNotes = create<NotesState>((set) => ({
+  notes: {},
+  setNote: (sessionId, text) =>
+    set((s) => {
+      const notes = { ...s.notes };
+      // A cleared note is a deleted note. Only exactly empty, though: dropping
+      // whitespace too would swallow the blank lines someone types to make
+      // room at the top of a note that has nothing in it yet.
+      if (text) notes[sessionId] = text;
+      else delete notes[sessionId];
+      return { notes };
+    }),
+  removeNote: (sessionId) =>
+    set((s) => {
+      if (!(sessionId in s.notes)) return s;
+      const notes = { ...s.notes };
+      delete notes[sessionId];
+      return { notes };
+    }),
+  hydrate: (notes) => set({ notes }),
+}));
+
+const FILE = "thel-notes.json";
+const KEY = "notes";
+
+let storePromise: Promise<Store> | null = null;
+const getStore = () =>
+  (storePromise ??= load(FILE, { autoSave: false, defaults: {} }));
+
+// True while applying a change synced in from another profile window, so the
+// persistence subscriber skips it and can't ping-pong the write back.
+let applyingRemote = false;
+let synced = false;
+// The last map this window wrote. The store resource is shared, so our own
+// writes come back through onKeyChange; replaying one would undo whatever was
+// typed since it went out.
+let lastWritten: string | null = null;
+
+function applyNotes(saved: Record<string, string> | undefined) {
+  if (!saved) return;
+  if (JSON.stringify(saved) === lastWritten) return;
+  applyingRemote = true;
+  useNotes.getState().hydrate(saved);
+  applyingRemote = false;
+}
+
+export async function hydrateNotes(): Promise<void> {
+  try {
+    const store = await getStore();
+    applyNotes(await store.get<Record<string, string>>(KEY));
+    // Every window writes the whole map, so a window that never re-read would
+    // overwrite another's notes with its own stale copy. Subscribe once.
+    if (!synced) {
+      synced = true;
+      await store.onKeyChange<Record<string, string>>(KEY, applyNotes);
+    }
+  } catch (e) {
+    console.error("failed to load notes", e);
+  }
+}
+
+const writer = debouncedWriter<Record<string, string>>(async (notes) => {
+  try {
+    const store = await getStore();
+    lastWritten = JSON.stringify(notes);
+    await store.set(KEY, notes);
+    await store.save();
+  } catch (e) {
+    console.error("failed to save notes", e);
+  }
+}, 400);
+
+/** Write any pending note change immediately (e.g. before the app closes). */
+export const flushNotes = writer.flush;
+
+export function startNotePersistence(): () => void {
+  return useNotes.subscribe((state) => {
+    if (applyingRemote) return; // a synced-in change, not a local edit
+    writer.schedule(state.notes);
+  });
+}

--- a/src/store/sessions.ts
+++ b/src/store/sessions.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import { killTerminalWindow } from "@/lib/pty";
+import { useNotes } from "@/store/notes";
 
 export interface Terminal {
   id: string;
@@ -297,6 +298,8 @@ export const useSessions = create<SessionState>((set, get) => ({
         for (const t of g.terminals) void killTerminalWindow(id, t.id);
       }
     }
+    // The session is gone, so its notes have nothing left to describe.
+    useNotes.getState().removeNote(id);
     set((s) => {
       const idx = s.sessions.findIndex((x) => x.id === id);
       const sessions = s.sessions.filter((x) => x.id !== id);

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -95,6 +95,11 @@ interface UIState {
   openSessionUsage: (sessionId: string) => void;
   closeSessionUsage: () => void;
 
+  // The session whose notes panel is open (null = closed).
+  sessionNotes: string | null;
+  openSessionNotes: (sessionId: string) => void;
+  closeSessionNotes: () => void;
+
   // The "add an icon to the library" dialog (global, not session-specific).
   addIconOpen: boolean;
   setAddIconOpen: (open: boolean) => void;
@@ -208,6 +213,10 @@ export const useUI = create<UIState>((set) => ({
   sessionUsage: null,
   openSessionUsage: (sessionId) => set({ sessionUsage: sessionId }),
   closeSessionUsage: () => set({ sessionUsage: null }),
+
+  sessionNotes: null,
+  openSessionNotes: (sessionId) => set({ sessionNotes: sessionId }),
+  closeSessionNotes: () => set({ sessionNotes: null }),
 
   addIconOpen: false,
   setAddIconOpen: (open) => set({ addIconOpen: open }),

--- a/tests/session-notes.spec.ts
+++ b/tests/session-notes.spec.ts
@@ -1,0 +1,124 @@
+import { test } from "./app";
+import { gotoApp, expect } from "./app";
+import type { Page } from "@playwright/test";
+
+async function createSession(page: Page) {
+  await page.keyboard.press("Control+Shift+N");
+  const create = page.getByRole("button", { name: "Create session" });
+  await expect(create).toBeEnabled();
+  await create.click();
+}
+
+const rows = (page: Page) => page.locator("[data-session-list] [data-row-id]");
+
+async function openNotes(page: Page, row: ReturnType<typeof rows>) {
+  await row.click({ button: "right" });
+  await page.getByRole("menuitem", { name: "Notes" }).click();
+}
+
+test("notes are written as markdown and render on save", async ({ page }) => {
+  await gotoApp(page);
+  await createSession(page);
+  const panel = page.getByRole("dialog");
+
+  await openNotes(page, rows(page).first());
+  // A session with no notes opens straight into the editor.
+  const editor = panel.getByRole("textbox");
+  await expect(editor).toBeVisible();
+  await editor.fill("## Plan\n\n- [ ] ship it");
+
+  await panel.getByRole("button", { name: "Save" }).click();
+  await expect(panel.getByText("Plan")).toBeVisible();
+  const box = panel.getByRole("checkbox");
+  await expect(box).not.toBeChecked();
+
+  // Ticking a rendered checkbox writes the change back into the markdown.
+  await box.check();
+  await expect(box).toBeChecked();
+  await panel.getByRole("button", { name: "Edit" }).click();
+  await expect(editor).toHaveValue("## Plan\n\n- [x] ship it");
+});
+
+test("Enter continues a checklist and Ctrl+S saves", async ({ page }) => {
+  await gotoApp(page);
+  await createSession(page);
+  const panel = page.getByRole("dialog");
+
+  await openNotes(page, rows(page).first());
+  const editor = panel.getByRole("textbox");
+  await editor.fill("- [x] first");
+  await editor.press("End");
+  await editor.press("Enter");
+  await editor.type("second");
+  await expect(editor).toHaveValue("- [x] first\n- [ ] second");
+
+  // Enter on the empty item that follows ends the list.
+  await editor.press("Enter");
+  await editor.press("Enter");
+  await expect(editor).toHaveValue("- [x] first\n- [ ] second\n");
+
+  await editor.press("Control+s");
+  await expect(editor).toBeHidden();
+  await expect(panel.getByRole("checkbox")).toHaveCount(2);
+
+  // The rendered view takes focus on save, so Ctrl+Enter goes back to editing.
+  await page.keyboard.press("Control+Enter");
+  await expect(editor).toBeVisible();
+});
+
+test("Escape leaves the editor before it closes the panel", async ({ page }) => {
+  await gotoApp(page);
+  await createSession(page);
+  const panel = page.getByRole("dialog");
+
+  await openNotes(page, rows(page).first());
+  const editor = panel.getByRole("textbox");
+  await editor.fill("half a thought");
+
+  await editor.press("Escape");
+  await expect(editor).toBeHidden();
+  await expect(panel).toBeVisible();
+
+  await page.keyboard.press("Escape");
+  await expect(panel).toBeHidden();
+});
+
+test("notes survive closing and reopening the panel", async ({ page }) => {
+  await gotoApp(page);
+  await createSession(page);
+  const panel = page.getByRole("dialog");
+
+  await openNotes(page, rows(page).first());
+  await panel.getByRole("textbox").fill("remember this");
+  // The shortcut is suppressed while an input has focus, so leave the editor
+  // first; that is also how the panel behaves for real.
+  await panel.getByRole("button", { name: "Save" }).click();
+  await page.keyboard.press("Control+Alt+N");
+  await expect(panel).toBeHidden();
+
+  await page.keyboard.press("Control+Alt+N");
+  await expect(panel.getByText("remember this")).toBeVisible();
+  // The panel takes focus as it opens, so its keys work without a click first.
+  await page.keyboard.press("Control+Enter");
+  await expect(panel.getByRole("textbox")).toBeFocused();
+});
+
+test("closing a session takes its notes with it", async ({ page }) => {
+  await gotoApp(page);
+  await createSession(page);
+  const panel = page.getByRole("dialog");
+
+  await openNotes(page, rows(page).first());
+  await panel.getByRole("textbox").fill("scratch");
+  await panel.getByRole("button", { name: "Save" }).click();
+
+  await rows(page).first().click({ button: "right" });
+  await page.getByRole("menuitem", { name: "Close" }).click();
+  await page.getByRole("button", { name: "Close session" }).click();
+  await expect(rows(page)).toHaveCount(0);
+
+  // A new session reuses no ids, so its notes start empty.
+  await createSession(page);
+  await openNotes(page, rows(page).first());
+  await expect(panel.getByRole("textbox")).toHaveValue("");
+});


### PR DESCRIPTION
A long-running session carries state the terminal does not: what was asked, what is still open, which step comes next. That has had nowhere to live inside thel, so it ends up in a scratch file somewhere else or is lost with the session. So these changes give every session a notes panel, docked beside it and opened from the session context menu or Ctrl+Alt+N.

Notes are written in GitHub-flavored markdown and render on save, so checklists can be ticked in place, and Enter continues a list the way GitHub's editor does. They live in thel's config dir keyed by session id, and closing a session takes its notes with it.

The markdown is parsed here rather than by a dependency: the parser emits React nodes instead of HTML, so a note never reaches innerHTML and no sanitizer is needed. Tables, autolinks, task lists and strikethrough are covered; nested emphasis, reference links and footnotes are not.