### PR TITLE
terminal: select and copy without the mouse

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ See [docs/install.md](docs/install.md) for that step and for direct downloads.
 - **Keyboard-friendly.** Every major action is reachable from the keyboard,
   through a fuzzy command palette with quick filters or direct shortcuts, and the
   keymap is fully rebindable and persisted.
+- **Copy mode.** Select and copy scrollback without touching the mouse: vi-style
+  motions (`hjkl`, `w`/`b`, `0`/`$`, `g`/`G`), Space to start the selection, `y`
+  to copy.
 - **Session icons.** Assign custom icons to your sessions to quickly identify
   them at a glance in the sidebar.
 - **Session notes.** A markdown scratchpad docked beside each session, with

--- a/src/components/TerminalPane.tsx
+++ b/src/components/TerminalPane.tsx
@@ -55,6 +55,12 @@ import {
   zoomedFontSize,
 } from "@/lib/theme";
 import { hasVisibleOutput } from "@/lib/ansi";
+import {
+  step as copyModeStep,
+  selection as copyModeSelection,
+  type CopyModeState,
+  type Grid,
+} from "@/lib/copyMode";
 
 type CopyMode = "raw" | "dedent" | "paragraph";
 
@@ -190,6 +196,9 @@ export function TerminalPane({
   const fitRef = useRef<FitAddon | null>(null);
   // Drives the enabled state of the right-click Copy items.
   const [hasSelection, setHasSelection] = useState(false);
+  // Copy mode is on for this pane (drives the hint bar); the cursor itself
+  // lives in a ref, since the key handler is registered once.
+  const [copyModeOn, setCopyModeOn] = useState(false);
   // The URL currently under the pointer (from the link addon's hover).
   const [linkUrl, setLinkUrl] = useState<string | null>(null);
   // What the pointer was on when the menu opened. Opening it blanks pointer
@@ -275,6 +284,36 @@ export function TerminalPane({
     const clearAttention = () => {
       if (hasAttention()) setAttention(tab.id, false);
     };
+    // Copy mode: a keyboard cursor over the buffer. With no anchor set the
+    // selection is the single cell under the cursor, so xterm's own selection
+    // highlight *is* the cursor and nothing extra has to be painted.
+    // ponytail: output keeps flowing while the mode is on. Anchors are absolute
+    // buffer rows, so they only drift once the scrollback ring trims; freeze the
+    // pane if that ever bites.
+    let copy: CopyModeState | null = null;
+    const grid = (): Grid => {
+      const buf = term.buffer.active;
+      return {
+        cols: term.cols,
+        rows: term.rows,
+        maxY: buf.length - 1,
+        line: (y) => buf.getLine(y)?.translateToString(true) ?? "",
+      };
+    };
+    const showCopy = () => {
+      const { column, row, length } = copyModeSelection(copy!, term.cols);
+      term.select(column, row, length);
+      // Follow the cursor when it walks out of the viewport.
+      const top = term.buffer.active.viewportY;
+      if (copy!.y < top) term.scrollLines(copy!.y - top);
+      else if (copy!.y >= top + term.rows)
+        term.scrollLines(copy!.y - top - term.rows + 1);
+    };
+    const exitCopy = () => {
+      copy = null;
+      setCopyModeOn(false);
+      term.clearSelection();
+    };
     term.attachCustomKeyEventHandler((e) => {
       if (e.type !== "keydown") return true;
       // A real keystroke means you're attending this terminal. Done here, not in
@@ -285,6 +324,7 @@ export function TerminalPane({
       // PageUp/PageDown still reach the program. Exclude Ctrl/Alt so the
       // tab/session move shortcuts (Ctrl+Shift+PageUp etc.) still get through.
       if (
+        !copy &&
         e.shiftKey &&
         !e.ctrlKey &&
         !e.altKey &&
@@ -295,19 +335,36 @@ export function TerminalPane({
         term.scrollPages(e.key === "PageUp" ? -1 : 1);
         return false;
       }
-      if (matches(e, "terminal-copy-dedent")) {
+      // The copy combos keep working inside copy mode (and end it), so they're
+      // matched before copy mode claims the keyboard.
+      for (const mode of ["dedent", "paragraph", "raw"] as const) {
+        const id = mode === "raw" ? "terminal-copy" : `terminal-copy-${mode}`;
+        if (matches(e, id)) {
+          e.preventDefault();
+          copyTermSelection(term, mode);
+          if (copy) exitCopy();
+          return false;
+        }
+      }
+      if (copy) {
         e.preventDefault();
-        copyTermSelection(term, "dedent");
+        const r = copyModeStep(copy, e, grid());
+        if (r.kind === "exit") exitCopy();
+        else if (r.kind === "copy") {
+          copyTermSelection(term, "raw");
+          exitCopy();
+        } else if (r.kind === "state") {
+          copy = r.state;
+          showCopy();
+        }
         return false;
       }
-      if (matches(e, "terminal-copy-paragraph")) {
+      if (matches(e, "terminal-copy-mode")) {
         e.preventDefault();
-        copyTermSelection(term, "paragraph");
-        return false;
-      }
-      if (matches(e, "terminal-copy")) {
-        e.preventDefault();
-        copyTermSelection(term, "raw");
+        const buf = term.buffer.active;
+        copy = { x: buf.cursorX, y: buf.baseY + buf.cursorY, anchor: null };
+        setCopyModeOn(true);
+        showCopy();
         return false;
       }
       if (matches(e, "terminal-paste")) {
@@ -655,6 +712,15 @@ export function TerminalPane({
             <div className="pointer-events-none absolute bottom-1 left-1 max-w-[calc(100%-0.5rem)] truncate rounded border border-border bg-popover/90 px-1.5 py-0.5 text-xs text-muted-foreground shadow-sm">
               {linkUrl}
               <span className="pl-1.5 opacity-60">{OPEN_LINK_HINT}</span>
+            </div>
+          )}
+          {copyModeOn && (
+            <div
+              data-copy-mode
+              className="pointer-events-none absolute bottom-1 right-1 rounded border bg-popover/90 px-2 py-0.5 text-xs text-muted-foreground backdrop-blur-sm"
+            >
+              Copy mode · hjkl/arrows move · w/b word · Space select · y copy ·
+              Esc exit
             </div>
           )}
         </div>

--- a/src/lib/copyMode.test.ts
+++ b/src/lib/copyMode.test.ts
@@ -1,0 +1,131 @@
+import { test, expect, describe } from "vitest";
+import { step, selection, type Grid, type CopyModeState } from "./copyMode";
+
+// A 10x3 viewport over 4 buffer rows (one row of scrollback).
+const LINES = ["hello world", "  foo bar", "", "baz"];
+const grid: Grid = {
+  cols: 10,
+  rows: 3,
+  maxY: LINES.length - 1,
+  line: (y) => LINES[y] ?? "",
+};
+
+const at = (x: number, y: number, anchor: CopyModeState["anchor"] = null) => ({
+  x,
+  y,
+  anchor,
+});
+const key = (k: string, mods: Partial<KeyboardEvent> = {}) =>
+  ({ key: k, ctrlKey: false, metaKey: false, ...mods }) as KeyboardEvent;
+
+const moved = (s: CopyModeState, k: string, mods?: Partial<KeyboardEvent>) => {
+  const r = step(s, key(k, mods), grid);
+  if (r.kind !== "state") throw new Error(`expected state, got ${r.kind}`);
+  return r.state;
+};
+
+describe("motions", () => {
+  test("hjkl and arrows move one cell", () => {
+    expect(moved(at(1, 1), "l")).toMatchObject({ x: 2, y: 1 });
+    expect(moved(at(1, 1), "h")).toMatchObject({ x: 0, y: 1 });
+    expect(moved(at(1, 1), "ArrowUp")).toMatchObject({ x: 1, y: 0 });
+    expect(moved(at(1, 1), "ArrowDown")).toMatchObject({ x: 1, y: 2 });
+  });
+
+  test("motions clamp to the buffer instead of wrapping", () => {
+    expect(moved(at(0, 0), "h")).toMatchObject({ x: 0, y: 0 });
+    expect(moved(at(0, 0), "k")).toMatchObject({ x: 0, y: 0 });
+    expect(moved(at(9, 3), "l")).toMatchObject({ x: 9, y: 3 });
+    expect(moved(at(0, 3), "j")).toMatchObject({ x: 0, y: 3 });
+  });
+
+  test("0 and $ jump to the row's first and last non-blank column", () => {
+    expect(moved(at(4, 1), "0")).toMatchObject({ x: 0, y: 1 });
+    // "  foo bar" ends at column 8.
+    expect(moved(at(0, 1), "$")).toMatchObject({ x: 8, y: 1 });
+    // A blank row has no last column; stay at 0 rather than going negative.
+    expect(moved(at(5, 2), "$")).toMatchObject({ x: 0, y: 2 });
+  });
+
+  test("g and G jump to the top and bottom of the scrollback", () => {
+    expect(moved(at(4, 2), "g")).toMatchObject({ x: 0, y: 0 });
+    expect(moved(at(4, 0), "G")).toMatchObject({ x: 0, y: 3 });
+  });
+
+  test("paging is bounded by the buffer", () => {
+    expect(moved(at(0, 3), "PageUp")).toMatchObject({ y: 0 });
+    expect(moved(at(0, 0), "PageDown")).toMatchObject({ y: 3 });
+    expect(moved(at(0, 0), "d", { ctrlKey: true })).toMatchObject({ y: 1 });
+    expect(moved(at(0, 3), "u", { ctrlKey: true })).toMatchObject({ y: 2 });
+  });
+});
+
+describe("word motions", () => {
+  test("w walks to the next word, crossing rows", () => {
+    // "hello world" -> from 'h' to 'w'
+    expect(moved(at(0, 0), "w")).toMatchObject({ x: 6, y: 0 });
+    // Past the last word of a row, land on the next row's first word.
+    expect(moved(at(6, 0), "w")).toMatchObject({ x: 2, y: 1 });
+    // Blank rows are skipped on the way.
+    expect(moved(at(6, 1), "w")).toMatchObject({ x: 0, y: 3 });
+  });
+
+  test("b walks back to the start of the previous word", () => {
+    expect(moved(at(6, 0), "b")).toMatchObject({ x: 0, y: 0 });
+    // From the start of a row, back across the row boundary.
+    expect(moved(at(2, 1), "b")).toMatchObject({ x: 6, y: 0 });
+    // Mid-word goes to that word's own start, like vi.
+    expect(moved(at(8, 0), "b")).toMatchObject({ x: 6, y: 0 });
+  });
+
+  test("word motions stop at the buffer edges", () => {
+    expect(moved(at(0, 0), "b")).toMatchObject({ x: 0, y: 0 });
+    expect(moved(at(2, 3), "w")).toMatchObject({ y: 3 });
+  });
+});
+
+describe("selection", () => {
+  test("without an anchor it is the single cell under the cursor", () => {
+    expect(selection(at(3, 2), 10)).toEqual({ column: 3, row: 2, length: 1 });
+  });
+
+  test("an anchor selects the inclusive run, in either direction", () => {
+    expect(selection(at(5, 1, { x: 2, y: 1 }), 10)).toEqual({
+      column: 2,
+      row: 1,
+      length: 4,
+    });
+    // Cursor before the anchor: same run.
+    expect(selection(at(2, 1, { x: 5, y: 1 }), 10)).toEqual({
+      column: 2,
+      row: 1,
+      length: 4,
+    });
+    // Across rows the run wraps, which is what term.select() expects.
+    expect(selection(at(1, 2, { x: 8, y: 0 }), 10)).toEqual({
+      column: 8,
+      row: 0,
+      length: 14,
+    });
+  });
+
+  test("Space toggles the anchor at the cursor", () => {
+    const anchored = moved(at(4, 1), " ");
+    expect(anchored.anchor).toEqual({ x: 4, y: 1 });
+    expect(moved(anchored, "v").anchor).toBeNull();
+  });
+});
+
+describe("exits", () => {
+  test("Escape and q leave, Enter and y copy", () => {
+    expect(step(at(0, 0), key("Escape"), grid).kind).toBe("exit");
+    expect(step(at(0, 0), key("q"), grid).kind).toBe("exit");
+    expect(step(at(0, 0), key("Enter"), grid).kind).toBe("copy");
+    expect(step(at(0, 0), key("y"), grid).kind).toBe("copy");
+  });
+
+  test("unknown keys are swallowed, never passed to the program", () => {
+    expect(step(at(0, 0), key("z"), grid).kind).toBe("ignore");
+    expect(step(at(0, 0), key("a", { ctrlKey: true }), grid).kind).toBe("ignore");
+  });
+});

--- a/src/lib/copyMode.ts
+++ b/src/lib/copyMode.ts
@@ -1,0 +1,174 @@
+/**
+ * Keyboard copy mode: move a cursor over the terminal's buffer and select text
+ * without a mouse. Pure state so the motions are unit-testable; TerminalPane
+ * feeds it a Grid over xterm's buffer and renders the result with
+ * `term.select()`.
+ *
+ * With no anchor set, the "selection" is the single cell under the cursor, so
+ * xterm's own selection highlight doubles as the copy-mode cursor. That's why
+ * there is no custom cursor rendering anywhere.
+ *
+ * Rows are absolute buffer rows (scrollback included), the same coordinates
+ * `term.select()` and `buffer.getLine()` take.
+ */
+
+export interface Grid {
+  cols: number;
+  rows: number;
+  /** Last valid absolute row. */
+  maxY: number;
+  /** Text of an absolute row; may be shorter than `cols` (trailing blanks trimmed). */
+  line(y: number): string;
+}
+
+export interface CopyModeState {
+  x: number;
+  y: number;
+  anchor: { x: number; y: number } | null;
+}
+
+export type StepResult =
+  | { kind: "state"; state: CopyModeState }
+  | { kind: "copy" }
+  | { kind: "exit" }
+  /** Key belongs to copy mode's namespace but does nothing; swallow it. */
+  | { kind: "ignore" };
+
+const isWord = (c: string | undefined) => !!c && c !== " ";
+
+const clamp = (n: number, lo: number, hi: number) => Math.min(hi, Math.max(lo, n));
+
+/** Column of the last non-blank character on the row (0 when the row is blank). */
+function lineEnd(g: Grid, y: number): number {
+  return clamp(g.line(y).replace(/\s+$/, "").length - 1, 0, g.cols - 1);
+}
+
+function nextWord(s: CopyModeState, g: Grid): CopyModeState {
+  let { x, y } = s;
+  const at = () => g.line(y)[x];
+  const adv = () => {
+    if (x + 1 < g.cols) x++;
+    else if (y + 1 <= g.maxY) (y++, (x = 0));
+    else return false;
+    return true;
+  };
+  while (isWord(at()) && adv());
+  while (!isWord(at()) && adv());
+  return { ...s, x, y };
+}
+
+function prevWord(s: CopyModeState, g: Grid): CopyModeState {
+  let { x, y } = s;
+  const at = () => g.line(y)[x];
+  const back = () => {
+    if (x > 0) x--;
+    else if (y > 0) (y--, (x = g.cols - 1));
+    else return false;
+    return true;
+  };
+  if (!back()) return { ...s, x: 0 };
+  while (!isWord(at())) if (!back()) return { ...s, x, y };
+  // On a word character: walk back to that word's first column.
+  for (;;) {
+    const px = x;
+    const py = y;
+    if (!back()) return { ...s, x, y };
+    if (!isWord(at())) return { ...s, x: px, y: py };
+  }
+}
+
+function moveTo(s: CopyModeState, g: Grid, x: number, y: number): StepResult {
+  return {
+    kind: "state",
+    state: { ...s, x: clamp(x, 0, g.cols - 1), y: clamp(y, 0, g.maxY) },
+  };
+}
+
+/**
+ * Apply one keypress. Returns the next state, or that the mode should copy the
+ * current selection or exit. Every result means the key was consumed: copy mode
+ * owns the keyboard while it's on, so nothing leaks through to the program.
+ */
+export function step(s: CopyModeState, e: KeyboardEvent, g: Grid): StepResult {
+  const half = Math.max(1, Math.floor(g.rows / 2));
+  const ctrl = e.ctrlKey || e.metaKey;
+
+  if (ctrl) {
+    switch (e.key) {
+      case "u":
+        return moveTo(s, g, s.x, s.y - half);
+      case "d":
+        return moveTo(s, g, s.x, s.y + half);
+      case "b":
+        return moveTo(s, g, s.x, s.y - g.rows);
+      case "f":
+        return moveTo(s, g, s.x, s.y + g.rows);
+    }
+    // Other modified keys (app shortcuts) already ran in the global capture
+    // handler; don't let them read as motions.
+    return { kind: "ignore" };
+  }
+
+  switch (e.key) {
+    case "Escape":
+    case "q":
+      return { kind: "exit" };
+    case "Enter":
+    case "y":
+      return { kind: "copy" };
+    case " ":
+    case "v":
+      return {
+        kind: "state",
+        state: { ...s, anchor: s.anchor ? null : { x: s.x, y: s.y } },
+      };
+    case "ArrowLeft":
+    case "h":
+      return moveTo(s, g, s.x - 1, s.y);
+    case "ArrowRight":
+    case "l":
+      return moveTo(s, g, s.x + 1, s.y);
+    case "ArrowUp":
+    case "k":
+      return moveTo(s, g, s.x, s.y - 1);
+    case "ArrowDown":
+    case "j":
+      return moveTo(s, g, s.x, s.y + 1);
+    case "PageUp":
+      return moveTo(s, g, s.x, s.y - g.rows);
+    case "PageDown":
+      return moveTo(s, g, s.x, s.y + g.rows);
+    case "Home":
+    case "0":
+      return moveTo(s, g, 0, s.y);
+    case "End":
+    case "$":
+      return moveTo(s, g, lineEnd(g, s.y), s.y);
+    case "g":
+      return moveTo(s, g, 0, 0);
+    case "G":
+      return moveTo(s, g, 0, g.maxY);
+    case "w":
+      return { kind: "state", state: nextWord(s, g) };
+    case "b":
+      return { kind: "state", state: prevWord(s, g) };
+    default:
+      return { kind: "ignore" };
+  }
+}
+
+/**
+ * Arguments for `term.select(column, row, length)`: the run from the anchor to
+ * the cursor, inclusive, in either direction. Without an anchor it's the one
+ * cell under the cursor.
+ */
+export function selection(
+  s: CopyModeState,
+  cols: number,
+): { column: number; row: number; length: number } {
+  const cur = s.y * cols + s.x;
+  const anc = s.anchor ? s.anchor.y * cols + s.anchor.x : cur;
+  const lo = Math.min(anc, cur);
+  const hi = Math.max(anc, cur);
+  return { column: lo % cols, row: Math.floor(lo / cols), length: hi - lo + 1 };
+}

--- a/src/lib/keymap.ts
+++ b/src/lib/keymap.ts
@@ -181,6 +181,16 @@ export const SHORTCUTS: Shortcut[] = [
     run: () => {},
   },
   {
+    id: "terminal-copy-mode",
+    description: "Copy mode (select with the keyboard)",
+    terminalOnly: true,
+    defaultCombo: def(
+      { code: "Space", meta: true, shift: true },
+      { code: "Space", ctrl: true, shift: true },
+    ),
+    run: () => {},
+  },
+  {
     id: "next-terminal",
     description: "Next terminal",
     defaultCombo: { code: "PageDown", ctrl: true },

--- a/tests/copy-mode.spec.ts
+++ b/tests/copy-mode.spec.ts
@@ -1,0 +1,56 @@
+import { test, gotoApp, expect } from "./app";
+import type { Page } from "@playwright/test";
+
+async function sessionWithOutput(page: Page, text: string) {
+  await gotoApp(page);
+  await page.keyboard.press("Control+Shift+N");
+  const create = page.getByRole("button", { name: "Create session" });
+  await expect(create).toBeEnabled();
+  await create.click();
+  await expect(page.locator(".xterm-helper-textarea")).toBeFocused();
+  await page.evaluate(
+    (t) => (window as never as MockWindow).__TAURI_INTERNALS__.__emitTerminal(0, t),
+    text,
+  );
+}
+
+interface MockWindow {
+  __TAURI_INTERNALS__: { __emitTerminal(index: number, data: string): void };
+  __MOCK__: { clipboard?: string };
+}
+
+const clipboard = (page: Page) =>
+  page.evaluate(() => (window as never as MockWindow).__MOCK__.clipboard);
+const hint = (page: Page) => page.locator("[data-copy-mode]");
+
+test("copy mode selects and copies a line with the keyboard", async ({ page }) => {
+  // The mock prints "$ " when the session starts, so this lands on row 0.
+  await sessionWithOutput(page, "hello world\r\n");
+
+  await page.keyboard.press("Control+Shift+Space");
+  await expect(hint(page)).toBeVisible();
+
+  await page.keyboard.press("g"); // top of the buffer
+  await page.keyboard.press("Space"); // set the anchor
+  await page.keyboard.press("$"); // to the row's last non-blank column
+  await page.keyboard.press("y"); // copy and leave
+
+  await expect(hint(page)).toBeHidden();
+  expect(await clipboard(page)).toBe("$ hello world");
+});
+
+test("copy mode swallows keys instead of typing them", async ({ page }) => {
+  await sessionWithOutput(page, "hello\r\n");
+  await page.keyboard.press("Control+Shift+Space");
+  // 'j' is a motion here, not input; the shell line must not gain a character.
+  await page.keyboard.press("j");
+  await page.keyboard.press("Escape");
+  await expect(hint(page)).toBeHidden();
+
+  await page.keyboard.press("Control+Shift+Space");
+  await page.keyboard.press("g");
+  await page.keyboard.press("Space");
+  await page.keyboard.press("$");
+  await page.keyboard.press("Enter");
+  expect(await clipboard(page)).toBe("$ hello");
+});


### PR DESCRIPTION
Copying out of a terminal meant dragging a selection with the pointer, so the scrollback was out of reach in a keyboard-only session. This adds a copy mode: Ctrl+Shift+Space puts a cursor on the buffer, vi motions move it, Space starts the selection, and y or Enter copies and leaves.

It renders no cursor of its own. With no anchor set the selection is the single cell under the cursor, so xterm's own highlight is the cursor. Motions live in src/lib/copyMode.ts as pure state, testable away from a live terminal. Every key is swallowed while the mode is on, except the existing copy combos, which still copy and end the mode.