### PR TITLE
notes: keep one markdown file per session

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -494,6 +494,69 @@ fn open_url(url: String) -> Result<(), String> {
     cmd.spawn().map(|_| ()).map_err(|e| e.to_string())
 }
 
+/// Where a session's notes live: one markdown file per session in thel's
+/// config dir. Debug builds get their own folder for the same reason the store
+/// files are prefixed there, a dev run shares the bundle id with the installed
+/// app.
+fn note_path(app: &tauri::AppHandle, session_id: &str) -> Result<std::path::PathBuf, String> {
+    // The id comes from the frontend, so keep it to a bare filename: nothing
+    // here may reach outside the notes folder.
+    if session_id.is_empty()
+        || !session_id
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    {
+        return Err("invalid session id".into());
+    }
+    let dir = if cfg!(debug_assertions) {
+        "dev-notes"
+    } else {
+        "notes"
+    };
+    Ok(app
+        .path()
+        .app_config_dir()
+        .map_err(|e| e.to_string())?
+        .join(dir)
+        .join(format!("{session_id}.md")))
+}
+
+/// A session's notes, empty when it has none yet.
+#[tauri::command]
+fn read_note(app: tauri::AppHandle, session_id: String) -> Result<String, String> {
+    let path = note_path(&app, &session_id)?;
+    match std::fs::read_to_string(&path) {
+        Ok(text) => Ok(text),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(String::new()),
+        Err(e) => Err(e.to_string()),
+    }
+}
+
+/// Save a session's notes. Emptying them removes the file, so cleared notes
+/// leave nothing behind.
+#[tauri::command]
+fn write_note(app: tauri::AppHandle, session_id: String, text: String) -> Result<(), String> {
+    let path = note_path(&app, &session_id)?;
+    if text.is_empty() {
+        return delete_note(app, session_id);
+    }
+    if let Some(dir) = path.parent() {
+        std::fs::create_dir_all(dir).map_err(|e| e.to_string())?;
+    }
+    std::fs::write(&path, text).map_err(|e| e.to_string())
+}
+
+/// Drop a session's notes (its session was closed).
+#[tauri::command]
+fn delete_note(app: tauri::AppHandle, session_id: String) -> Result<(), String> {
+    let path = note_path(&app, &session_id)?;
+    match std::fs::remove_file(&path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e.to_string()),
+    }
+}
+
 /// The files on the clipboard (a file-manager "Copy"), as paths. Empty when
 /// the clipboard holds no file list, so a paste can fall back to text.
 #[tauri::command]
@@ -679,6 +742,9 @@ pub fn run() {
             notify,
             open_url,
             clipboard_files,
+            read_note,
+            write_note,
+            delete_note,
             git::git_info,
             git::worktree_info,
             git::list_worktrees,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,7 +26,7 @@ import { hydrateSessions, startPersistence, flushSessions } from "@/lib/persiste
 import { checkDaemon, killTerminalWindow } from "@/lib/pty";
 import { hydrateLaunchers, startLauncherPersistence, flushLaunchers } from "@/store/launchers";
 import { hydrateKeybindings, startKeybindingPersistence, flushKeybindings } from "@/store/keybindings";
-import { hydrateNotes, startNotePersistence, flushNotes } from "@/store/notes";
+import { flushNotes } from "@/store/notes";
 import { startIconSync } from "@/store/icons";
 import { refreshSessionGit } from "@/lib/launch";
 import { useGlobalShortcuts } from "@/lib/useGlobalShortcuts";
@@ -177,15 +177,6 @@ export default function App() {
     let unsubscribe = () => {};
     hydrateKeybindings().finally(() => {
       unsubscribe = startKeybindingPersistence();
-    });
-    return () => unsubscribe();
-  }, []);
-
-  // Restore + persist session notes.
-  useEffect(() => {
-    let unsubscribe = () => {};
-    hydrateNotes().finally(() => {
-      unsubscribe = startNotePersistence();
     });
     return () => unsubscribe();
   }, []);

--- a/src/components/SessionNotesPanel.tsx
+++ b/src/components/SessionNotesPanel.tsx
@@ -33,17 +33,32 @@ export function SessionNotesPanel() {
   const text = useNotes((s) => (sessionId ? (s.notes[sessionId] ?? "") : ""));
   const setNote = useNotes((s) => s.setNote);
   const [editing, setEditing] = useState(false);
+  // The note has been read from disk, so there is something to show.
+  const [ready, setReady] = useState(false);
   const editor = useRef<HTMLTextAreaElement>(null);
   const view = useRef<HTMLDivElement>(null);
   const panel = useRef<HTMLDivElement>(null);
   // Where the caret goes once a rewritten note has been committed to the DOM.
   const caret = useRef<number | null>(null);
 
-  // Open straight into the editor when there is nothing to render yet, and
-  // leave the editor when the panel moves to another session.
+  // Notes are read from disk on demand, so wait for the file before choosing
+  // between the editor and the rendered view: a session with nothing saved
+  // opens straight into the editor.
   useEffect(() => {
     if (!sessionId) return;
-    setEditing(!useNotes.getState().notes[sessionId]);
+    let live = true;
+    setReady(false);
+    void useNotes
+      .getState()
+      .loadNote(sessionId)
+      .then(() => {
+        if (!live) return;
+        setEditing(!useNotes.getState().notes[sessionId]);
+        setReady(true);
+      });
+    return () => {
+      live = false;
+    };
   }, [sessionId]);
 
   // The panel belongs to one session, so navigating away would leave it stale:
@@ -77,8 +92,8 @@ export function SessionNotesPanel() {
   // own keys work right away and the notes scroll with the keyboard. The
   // editor focuses itself on mount, so this only covers the rendered view.
   useEffect(() => {
-    if (sessionId && !editing) view.current?.focus();
-  }, [sessionId, editing]);
+    if (sessionId && ready && !editing) view.current?.focus();
+  }, [sessionId, ready, editing]);
 
   // Esc, on the window in the capture phase, ahead of the dismissable layers.
   // Radix would otherwise decide this: a menu that has just closed can still
@@ -162,7 +177,9 @@ export function SessionNotesPanel() {
           </DialogDescription>
         </div>
 
-        {editing ? (
+        {!ready ? (
+          <div className="flex-1" />
+        ) : editing ? (
           <textarea
             ref={editor}
             autoFocus

--- a/src/lib/persistDebounce.ts
+++ b/src/lib/persistDebounce.ts
@@ -21,5 +21,11 @@ export function debouncedWriter<T>(write: (v: T) => Promise<void>, delay: number
     timer = window.setTimeout(() => void flush(), delay);
   };
 
-  return { schedule, flush };
+  /** Drop a pending write, for when its target is being deleted anyway. */
+  const cancel = (): void => {
+    pending = null;
+    clearTimeout(timer);
+  };
+
+  return { schedule, flush, cancel };
 }

--- a/src/store/notes.ts
+++ b/src/store/notes.ts
@@ -1,97 +1,76 @@
 import { create } from "zustand";
-import { type Store } from "@tauri-apps/plugin-store";
+import { invoke } from "@tauri-apps/api/core";
 import { debouncedWriter } from "@/lib/persistDebounce";
-import { load } from "@/lib/storeFile";
 
-// Markdown notes, one per session, kept in thel's config dir. Sessions live in
-// per-profile layout files, but their ids are unique across profiles, so a
-// single notes file serves every window.
+// Markdown notes, one file per session under thel's config dir. Plain .md
+// rather than a store file: they are the user's own text, so they stay
+// readable and editable outside the app. A note is read when its panel first
+// opens, and closing a session removes its file.
 interface NotesState {
+  /** Loaded notes. A missing key means "not read from disk yet", not "empty". */
   notes: Record<string, string>;
   setNote: (sessionId: string, text: string) => void;
   /** Drop a session's notes (its session was closed). */
   removeNote: (sessionId: string) => void;
-  hydrate: (notes: Record<string, string>) => void;
+  /** Read a session's note into the store, once. */
+  loadNote: (sessionId: string) => Promise<void>;
 }
 
-export const useNotes = create<NotesState>((set) => ({
+// One debounced writer per session, so two panels can't overwrite each other.
+const writers = new Map<string, ReturnType<typeof debouncedWriter<string>>>();
+function writerFor(sessionId: string) {
+  let w = writers.get(sessionId);
+  if (!w) {
+    w = debouncedWriter<string>(async (text) => {
+      try {
+        await invoke("write_note", { sessionId, text });
+      } catch (e) {
+        console.error("failed to save notes", e);
+      }
+    }, 400);
+    writers.set(sessionId, w);
+  }
+  return w;
+}
+
+export const useNotes = create<NotesState>((set, get) => ({
   notes: {},
-  setNote: (sessionId, text) =>
-    set((s) => {
-      const notes = { ...s.notes };
-      // A cleared note is a deleted note. Only exactly empty, though: dropping
-      // whitespace too would swallow the blank lines someone types to make
-      // room at the top of a note that has nothing in it yet.
-      if (text) notes[sessionId] = text;
-      else delete notes[sessionId];
-      return { notes };
-    }),
-  removeNote: (sessionId) =>
+  setNote: (sessionId, text) => {
+    set((s) => ({ notes: { ...s.notes, [sessionId]: text } }));
+    writerFor(sessionId).schedule(text);
+  },
+  removeNote: (sessionId) => {
+    // Cancel first: a write scheduled seconds ago would otherwise land after
+    // the delete and put the file back.
+    writers.get(sessionId)?.cancel();
+    writers.delete(sessionId);
+    void invoke("delete_note", { sessionId }).catch((e) =>
+      console.error("failed to delete notes", e),
+    );
     set((s) => {
       if (!(sessionId in s.notes)) return s;
       const notes = { ...s.notes };
       delete notes[sessionId];
       return { notes };
-    }),
-  hydrate: (notes) => set({ notes }),
+    });
+  },
+  loadNote: async (sessionId) => {
+    if (get().notes[sessionId] !== undefined) return;
+    try {
+      const text = await invoke<string>("read_note", { sessionId });
+      // An edit may have landed while the read was in flight; it wins.
+      set((s) =>
+        s.notes[sessionId] === undefined
+          ? { notes: { ...s.notes, [sessionId]: text } }
+          : s,
+      );
+    } catch (e) {
+      console.error("failed to load notes", e);
+    }
+  },
 }));
 
-const FILE = "thel-notes.json";
-const KEY = "notes";
-
-let storePromise: Promise<Store> | null = null;
-const getStore = () =>
-  (storePromise ??= load(FILE, { autoSave: false, defaults: {} }));
-
-// True while applying a change synced in from another profile window, so the
-// persistence subscriber skips it and can't ping-pong the write back.
-let applyingRemote = false;
-let synced = false;
-// The last map this window wrote. The store resource is shared, so our own
-// writes come back through onKeyChange; replaying one would undo whatever was
-// typed since it went out.
-let lastWritten: string | null = null;
-
-function applyNotes(saved: Record<string, string> | undefined) {
-  if (!saved) return;
-  if (JSON.stringify(saved) === lastWritten) return;
-  applyingRemote = true;
-  useNotes.getState().hydrate(saved);
-  applyingRemote = false;
-}
-
-export async function hydrateNotes(): Promise<void> {
-  try {
-    const store = await getStore();
-    applyNotes(await store.get<Record<string, string>>(KEY));
-    // Every window writes the whole map, so a window that never re-read would
-    // overwrite another's notes with its own stale copy. Subscribe once.
-    if (!synced) {
-      synced = true;
-      await store.onKeyChange<Record<string, string>>(KEY, applyNotes);
-    }
-  } catch (e) {
-    console.error("failed to load notes", e);
-  }
-}
-
-const writer = debouncedWriter<Record<string, string>>(async (notes) => {
-  try {
-    const store = await getStore();
-    lastWritten = JSON.stringify(notes);
-    await store.set(KEY, notes);
-    await store.save();
-  } catch (e) {
-    console.error("failed to save notes", e);
-  }
-}, 400);
-
 /** Write any pending note change immediately (e.g. before the app closes). */
-export const flushNotes = writer.flush;
-
-export function startNotePersistence(): () => void {
-  return useNotes.subscribe((state) => {
-    if (applyingRemote) return; // a synced-in change, not a local edit
-    writer.schedule(state.notes);
-  });
-}
+export const flushNotes = async (): Promise<void> => {
+  await Promise.all([...writers.values()].map((w) => w.flush()));
+};

--- a/tests/session-notes.spec.ts
+++ b/tests/session-notes.spec.ts
@@ -101,6 +101,11 @@ test("notes survive closing and reopening the panel", async ({ page }) => {
   // The panel takes focus as it opens, so its keys work without a click first.
   await page.keyboard.press("Control+Enter");
   await expect(panel.getByRole("textbox")).toBeFocused();
+
+  // Nothing is kept in memory across a restart: this comes back off disk.
+  await page.reload();
+  await openNotes(page, rows(page).first());
+  await expect(panel.getByText("remember this")).toBeVisible();
 });
 
 test("closing a session takes its notes with it", async ({ page }) => {

--- a/tests/tauri.ts
+++ b/tests/tauri.ts
@@ -259,6 +259,18 @@ function install(config: MockConfig) {
         (w.__MOCK__ as Record<string, unknown>).created = list;
         return String(args.path);
       }
+      // Session notes, in localStorage so they survive a reload like the files
+      // they stand in for.
+      case "read_note":
+        return localStorage.getItem("__note__" + args.sessionId) ?? "";
+      case "write_note":
+        if (args.text)
+          localStorage.setItem("__note__" + args.sessionId, String(args.text));
+        else localStorage.removeItem("__note__" + args.sessionId);
+        return null;
+      case "delete_note":
+        localStorage.removeItem("__note__" + args.sessionId);
+        return null;
       case "check_daemon":
         return m.daemonHealth ?? "none";
       case "restart_daemon":


### PR DESCRIPTION
Every session's notes shared a single thel-notes.json, so each
keystroke rewrote the whole map, startup read notes for sessions
whose panel never opened, and closing one session meant rewriting
the file that held all the others. The text was also buried in a
JSON blob, out of reach of the editors and greps the user already
has. So these changes give each session its own .md file under the
notes folder in thel's config dir, read when its panel first opens
and removed with the session.

Reading and writing go through three Rust commands rather than the
store plugin, which can only rewrite a file and never remove one:
without a delete, a closed session would leave an empty file behind
forever. Clearing a note removes its file for the same reason. The
cross-window sync that guarded the shared map is gone too, since a
session belongs to exactly one profile and so appears in exactly
one window.
