### PR TITLE
sessions: fetch remote branches to base a worktree on

### DIFF
--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -118,23 +118,80 @@ pub fn worktree_info(cwd: String) -> Option<WorktreeInfo> {
 pub struct Branches {
     /// Local branch names, most recently committed first.
     branches: Vec<String>,
+    /// Remote-tracking branches ("origin/main"), most recently committed first.
+    remotes: Vec<String>,
     /// The repo's main/default branch, whatever it's named.
     default_branch: Option<String>,
+    /// The repo has a remote, so there is something to fetch from.
+    has_remote: bool,
+}
+
+/// Short names of the refs under `pattern`, most recently committed first.
+fn ref_names(cwd: &str, pattern: &str) -> Vec<String> {
+    git(
+        cwd,
+        &["for-each-ref", "--sort=-committerdate", "--format=%(refname:short)", pattern],
+    )
+    .map(|s| s.lines().map(|l| l.to_string()).collect())
+    .unwrap_or_default()
 }
 
 #[tauri::command]
 pub fn branches(cwd: String) -> Branches {
-    let branches: Vec<String> = git(
-        &cwd,
-        &["for-each-ref", "--sort=-committerdate", "--format=%(refname:short)", "refs/heads"],
-    )
-    .map(|s| s.lines().map(|l| l.to_string()).collect())
-    .unwrap_or_default();
+    let branches = ref_names(&cwd, "refs/heads");
+    // Every remote-tracking branch shortens to "<remote>/<branch>". The one ref
+    // that comes back without a slash is refs/remotes/<remote>/HEAD, a symref
+    // onto the default branch rather than a branch to start from.
+    let remotes: Vec<String> = ref_names(&cwd, "refs/remotes")
+        .into_iter()
+        .filter(|r| r.contains('/'))
+        .collect();
     let default_branch = detect_default_branch(&cwd, &branches);
+    let has_remote = git(&cwd, &["remote"])
+        .map(|s| !s.is_empty())
+        .unwrap_or(false);
     Branches {
         branches,
+        remotes,
         default_branch,
+        has_remote,
     }
+}
+
+/// Fetch from the repo's remote so a branch pushed since the last fetch can be
+/// used as a base.
+///
+/// A plain `git fetch`, which takes the remote the current branch tracks and
+/// falls back to origin. Deliberately not `--all`, so that one unreachable
+/// remote among several doesn't fail a fetch the others answered, and not
+/// `--prune`: deleting remote-tracking refs is not what a button offering to
+/// find new branches should do behind the user's back.
+///
+/// Async so the fetch runs off the main thread and the window stays responsive.
+/// `GIT_TERMINAL_PROMPT=0` keeps git from waiting on a password prompt that a
+/// windowed app has no terminal to show. A credential helper still runs, so an
+/// https remote works when the helper is on the app's PATH; when it isn't, the
+/// error says so instead of hanging.
+/// ponytail: no timeout, so an unreachable host takes git's own; add one if
+/// that wait turns out to be long enough to matter.
+#[tauri::command]
+pub async fn fetch_remote(cwd: String) -> Result<(), String> {
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(&cwd)
+        .arg("fetch")
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .output()
+        .map_err(|e| e.to_string())?;
+    if out.status.success() {
+        return Ok(());
+    }
+    let err = String::from_utf8_lossy(&out.stderr).trim().to_string();
+    Err(if err.is_empty() {
+        "git fetch failed.".into()
+    } else {
+        err
+    })
 }
 
 fn detect_default_branch(cwd: &str, branches: &[String]) -> Option<String> {
@@ -298,6 +355,53 @@ mod tests {
         // No origin remote, so it falls back to the conventional "main".
         assert_eq!(b.default_branch.as_deref(), Some("main"));
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn fetch_remote_adds_new_branches_without_deleting_any() {
+        if !git_available() {
+            return;
+        }
+        let upstream = setup_repo();
+        let clone = upstream.with_extension("clone");
+        let _ = std::fs::remove_dir_all(&clone);
+        let ok = Command::new("git")
+            .args(["clone", upstream.to_str().unwrap(), clone.to_str().unwrap()])
+            .output()
+            .unwrap()
+            .status
+            .success();
+        assert!(ok, "clone failed");
+        let c = clone.to_string_lossy().to_string();
+
+        let before = branches(c.clone());
+        assert!(before.has_remote);
+        assert!(before.remotes.iter().any(|r| r == "origin/main"));
+        // refs/remotes/origin/HEAD shortens to a bare "origin"; it is a symref,
+        // not a branch, so it must not be offered as a base.
+        assert!(!before.remotes.iter().any(|r| r == "origin"));
+        assert!(!before.remotes.iter().any(|r| r == "origin/pushed"));
+
+        // A branch that appeared upstream after the clone shows up once fetched.
+        run(&upstream, &["branch", "pushed"]);
+        tauri::async_runtime::block_on(fetch_remote(c.clone())).unwrap();
+        let after = branches(c.clone());
+        assert!(after.remotes.iter().any(|r| r == "origin/pushed"));
+        // Fetching adds no local branch; the base is a remote-tracking ref.
+        assert!(!after.branches.iter().any(|b| b == "pushed"));
+
+        // Fetching only ever adds. A branch deleted upstream keeps its
+        // remote-tracking ref here: pruning it is the user's call to make, not
+        // a side effect of asking what new branches exist.
+        run(&upstream, &["branch", "-D", "pushed"]);
+        tauri::async_runtime::block_on(fetch_remote(c.clone())).unwrap();
+        assert!(branches(c).remotes.iter().any(|r| r == "origin/pushed"));
+
+        // A repo with no remote reports nothing to fetch from.
+        assert!(!branches(upstream.to_string_lossy().to_string()).has_remote);
+
+        let _ = std::fs::remove_dir_all(&upstream);
+        let _ = std::fs::remove_dir_all(&clone);
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -683,6 +683,7 @@ pub fn run() {
             git::worktree_info,
             git::list_worktrees,
             git::branches,
+            git::fetch_remote,
             git::create_worktree,
             git::remove_worktree,
         ])

--- a/src/components/NewSessionDialog.tsx
+++ b/src/components/NewSessionDialog.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { open } from "@tauri-apps/plugin-dialog";
-import { Folder, GitBranch, Check, ChevronRight } from "lucide-react";
+import { Folder, GitBranch, Check, ChevronRight, RefreshCw } from "lucide-react";
 import { cn, inputClass } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import {
@@ -17,6 +17,7 @@ import {
   listWorktrees,
   gitInfo,
   branches,
+  fetchRemote,
   createWorktree,
   worktreeInfo,
   type Worktree,
@@ -45,6 +46,11 @@ export function NewSessionDialog() {
   const [repoRoot, setRepoRoot] = useState<string | null>(null);
   const [worktrees, setWorktrees] = useState<Worktree[]>([]);
   const [branchList, setBranchList] = useState<string[]>([]);
+  const [remoteList, setRemoteList] = useState<string[]>([]);
+  const [hasRemote, setHasRemote] = useState(false);
+  const [fetching, setFetching] = useState(false);
+  const [fetchError, setFetchError] = useState<string | null>(null);
+  const [fetched, setFetched] = useState(false);
   const [selected, setSelected] = useState<string | null>(null);
   const [notFound, setNotFound] = useState(false);
 
@@ -67,6 +73,26 @@ export function NewSessionDialog() {
   // Anchor to a directory: select it and load its git state (if any). Paths
   // arrive with a trailing slash from the default and from completions; strip
   // it so the anchored path compares equal to the ones git reports.
+  const clearBranches = () => {
+    setBranchList([]);
+    setRemoteList([]);
+    setHasRemote(false);
+    setFetchError(null);
+  };
+
+  // Load a repo's branches; the fetch button reloads through here as well.
+  const loadBranches = async (root: string) => {
+    const b = await branches(root).catch(() => null);
+    if (!b) {
+      clearBranches();
+      return null;
+    }
+    setBranchList(b.branches);
+    setRemoteList(b.remotes);
+    setHasRemote(b.has_remote);
+    return b;
+  };
+
   const loadDir = async (raw: string) => {
     const dir = raw.length > 1 ? raw.replace(/\/+$/, "") : raw;
     const req = ++loadReq.current;
@@ -81,7 +107,7 @@ export function NewSessionDialog() {
       setSelected(null);
       setRepoRoot(null);
       setWorktrees([]);
-      setBranchList([]);
+      clearBranches();
     };
     if (!dir) {
       setNotFound(false);
@@ -105,16 +131,15 @@ export function NewSessionDialog() {
       setRepoRoot(info.repo_root);
       const [wts, b] = await Promise.all([
         listWorktrees(info.repo_root).catch(() => []),
-        branches(info.repo_root).catch(() => ({ branches: [], default_branch: null })),
+        loadBranches(info.repo_root),
       ]);
       setWorktrees(wts);
-      setBranchList(b.branches);
       // Default the base to the repo's main branch (falls back to HEAD on use).
-      setBase(b.default_branch ?? "");
+      setBase(b?.default_branch ?? "");
     } else {
       setRepoRoot(null);
       setWorktrees([]);
-      setBranchList([]);
+      clearBranches();
     }
   };
 
@@ -128,7 +153,7 @@ export function NewSessionDialog() {
     setCwd(null);
     setRepoRoot(null);
     setWorktrees([]);
-    setBranchList([]);
+    clearBranches();
     setSelected(null);
     setTab("create");
     setTabPicked(false);
@@ -176,6 +201,24 @@ export function NewSessionDialog() {
     if (!dir || Array.isArray(dir)) return;
     setPathInput(abbreviatePath(dir));
     await loadDir(dir);
+  };
+
+  // Pull down refs so a branch pushed since the last fetch can be used as a
+  // base. Reloads the list even when the fetch reports an error, since a fetch
+  // can bring refs down and still exit non-zero.
+  const fetchRefs = async () => {
+    if (!repoRoot || fetching) return;
+    setFetching(true);
+    setFetchError(null);
+    try {
+      await fetchRemote(repoRoot);
+      setFetched(true);
+      setTimeout(() => setFetched(false), 2000);
+    } catch (e) {
+      setFetchError(String(e));
+    }
+    await loadBranches(repoRoot);
+    setFetching(false);
   };
 
   // Default worktree location: a sibling of the project dir, "PROJECT.branch".
@@ -343,14 +386,45 @@ export function NewSessionDialog() {
                     </button>
                     {showOpts && (
                       <div className="mt-2 space-y-3">
-                        <Field label="Base">
-                          <BranchInput
-                            value={base}
-                            onChange={setBase}
-                            options={branchList}
-                            placeholder="HEAD"
-                          />
-                        </Field>
+                        <div className="flex items-end gap-2">
+                          <div className="min-w-0 flex-1">
+                            <Field label="Base">
+                              <BranchInput
+                                value={base}
+                                onChange={setBase}
+                                options={[...branchList, ...remoteList]}
+                                placeholder="HEAD"
+                              />
+                            </Field>
+                          </div>
+                          {hasRemote && (
+                            <ActionTooltip label="Fetch remote branches">
+                              <Button
+                                variant="ghost"
+                                size="icon"
+                                onClick={fetchRefs}
+                                disabled={fetching}
+                                aria-label="Fetch remote branches"
+                              >
+                                {fetched ? (
+                                  <Check className="size-4" />
+                                ) : (
+                                  <RefreshCw
+                                    className={cn(
+                                      "size-4",
+                                      fetching && "animate-spin",
+                                    )}
+                                  />
+                                )}
+                              </Button>
+                            </ActionTooltip>
+                          )}
+                        </div>
+                        {fetchError && (
+                          <p className="break-words text-xs text-destructive">
+                            {fetchError}
+                          </p>
+                        )}
                         <Field label="Location">
                           <input
                             value={shownPath}

--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -30,11 +30,16 @@ export const listWorktrees = (cwd: string) =>
 
 export interface Branches {
   branches: string[];
+  remotes: string[];
   default_branch: string | null;
+  has_remote: boolean;
 }
 
 export const branches = (cwd: string) =>
   invoke<Branches>("branches", { cwd });
+
+export const fetchRemote = (cwd: string) =>
+  invoke<void>("fetch_remote", { cwd });
 
 export const createWorktree = (
   repoRoot: string,

--- a/tests/new-session.spec.ts
+++ b/tests/new-session.spec.ts
@@ -179,3 +179,46 @@ test("Enter selects the highlighted folder completion", async ({ page }) => {
     page.getByText("Anchor a session to a folder or git worktree."),
   ).toBeVisible();
 });
+
+test("fetching offers a branch that was only pushed upstream", async ({
+  page,
+}) => {
+  await gotoApp(page, {
+    git: { ...gitRepo, remotes: ["origin/main"], fetchedRemotes: ["origin/new-feature"] },
+  });
+  await openNew(page);
+  await page.getByRole("tab", { name: "Create Worktree" }).click();
+  await page.getByRole("button", { name: "Options" }).click();
+
+  const base = page.getByPlaceholder("HEAD");
+  await base.click();
+  await expect(page.getByRole("button", { name: "origin/main" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "origin/new-feature" })).toBeHidden();
+
+  await page.getByRole("button", { name: "Fetch remote branches" }).click();
+  await base.click();
+  const pushed = page.getByRole("button", { name: "origin/new-feature" });
+  await expect(pushed).toBeVisible();
+
+  // Picking it makes the fetched branch the base the worktree starts from.
+  await pushed.click();
+  await expect(base).toHaveValue("origin/new-feature");
+  await page.getByPlaceholder("my-new-branch").fill("my-fix");
+  await page.getByRole("button", { name: "Create session" }).click();
+  const created = await page.evaluate(
+    () => (window as Record<string, any>).__MOCK__.created?.[0],
+  );
+  expect(created.base).toBe("origin/new-feature");
+  expect(created.branch).toBe("my-fix");
+});
+
+test("a repo with no remote offers no fetch button", async ({ page }) => {
+  await gotoApp(page, { git: gitRepo });
+  await openNew(page);
+  await page.getByRole("tab", { name: "Create Worktree" }).click();
+  await page.getByRole("button", { name: "Options" }).click();
+  await expect(page.getByPlaceholder("HEAD")).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Fetch remote branches" }),
+  ).toBeHidden();
+});

--- a/tests/tauri.ts
+++ b/tests/tauri.ts
@@ -25,6 +25,9 @@ export interface MockConfig {
     branch?: string;
     dirty?: boolean;
     branches?: string[];
+    remotes?: string[];
+    // Remote branches that only exist upstream, so they appear once fetched.
+    fetchedRemotes?: string[];
     worktrees?: {
       path: string;
       branch: string | null;
@@ -245,11 +248,22 @@ function install(config: MockConfig) {
           detached: false,
           ...wt,
         }));
-      case "branches":
+      case "branches": {
+        const store = w.__MOCK__ as Record<string, unknown>;
+        const pulled = store.fetched ? m.git?.fetchedRemotes || [] : [];
+        const remotes = [...(m.git?.remotes || []), ...pulled];
         return {
           branches: m.git?.branches || [],
+          remotes,
           default_branch: m.git?.branches?.[0] ?? null,
+          has_remote: remotes.length > 0 || !!m.git?.fetchedRemotes?.length,
         };
+      }
+      case "fetch_remote": {
+        const store = w.__MOCK__ as Record<string, unknown>;
+        store.fetched = ((store.fetched as number) || 0) + 1;
+        return null;
+      }
       case "create_worktree": {
         const created = (w.__MOCK__ as Record<string, unknown>).created as
           | unknown[]


### PR DESCRIPTION
The new session dialog only ever listed local branches, so a branch a teammate had just pushed could not be used as a base until the user dropped to a terminal and fetched by hand. That made the common case of starting work on top of someone else's branch a two-tool job.

So the Base field now also offers remote-tracking branches, and a button beside it fetches so a branch pushed since the last fetch shows up. The fetch is plain `git fetch`, deliberately without --all or --prune: one unreachable remote among several should not fail the fetches that succeeded, and deleting remote-tracking refs is not something a button offering to find new branches should do behind the user's back. It runs async with GIT_TERMINAL_PROMPT=0 so the window stays responsive and git reports a missing credential helper instead of waiting on a prompt a windowed app has no terminal to show.

A remote branch is a base only, never checked out and tracked, so creating a local branch named after an existing origin/x is still allowed. The button is hidden when the repo has no remote, and shows a check mark briefly once a fetch succeeds.