### PR TITLE
ci: release a Linux build for aarch64 too

### DIFF
--- a/.github/actions/build-binary/action.yml
+++ b/.github/actions/build-binary/action.yml
@@ -11,6 +11,9 @@ outputs:
   tarball:
     description: Path to the packaged tar.xz.
     value: ${{ steps.package.outputs.tarball }}
+  arch:
+    description: Architecture of the built binary, as uname -m reports it.
+    value: ${{ steps.package.outputs.arch }}
 
 runs:
   using: composite
@@ -54,11 +57,14 @@ runs:
       run: |
         bin=src-tauri/target/release/thel
         test -f "$bin" || { echo "binary not found at $bin" >&2; exit 1; }
+        # Every build is native, so the runner's arch is the binary's arch.
+        arch=$(uname -m)
         if [ -n "$VERSION" ]; then
-          tarball="thel-${VERSION}-linux-x86_64.tar.xz"
+          tarball="thel-${VERSION}-linux-${arch}.tar.xz"
         else
-          tarball="thel-linux-x86_64.tar.xz"
+          tarball="thel-linux-${arch}.tar.xz"
         fi
         # tar the binary alone (keeps the executable bit).
         tar -cJf "$tarball" -C "$(dirname "$bin")" "$(basename "$bin")"
         echo "tarball=$tarball" >> "$GITHUB_OUTPUT"
+        echo "arch=$arch" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,9 @@
 name: build
 
-# Build the Linux binary on every pull request and on main, upload it as a run
-# artifact you can download from the workflow run, and report its size: to the
-# job summary always, and as a pull request comment when the token allows.
+# Build the Linux binary for each architecture on every pull request and on
+# main, upload each as a run artifact you can download from the workflow run,
+# and report the x86_64 size: to the job summary always, and as a pull request
+# comment when the token allows.
 on:
   pull_request:
   push:
@@ -13,7 +14,13 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    # One native runner per architecture; no cross-compiling. Let the other
+    # leg finish so a failure names the architecture that broke.
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ubuntu-latest, ubuntu-24.04-arm]
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       # Needed to post the size comment. GitHub grants this only to pull
@@ -25,7 +32,10 @@ jobs:
       - id: build
         uses: ./.github/actions/build-binary
 
+      # Only x86_64 reports size: the aarch64 leg exists to catch build
+      # breakage, and two legs editing one comment would race each other.
       - id: measure
+        if: matrix.runner == 'ubuntu-latest'
         env:
           TARBALL: ${{ steps.build.outputs.tarball }}
         run: |
@@ -53,6 +63,7 @@ jobs:
       # is read-only whatever `permissions` says, so the API call would 403.
       # Skip rather than fail a build that is otherwise fine.
       - if: >-
+          matrix.runner == 'ubuntu-latest' &&
           github.event_name == 'pull_request' &&
           github.event.pull_request.head.repo.full_name == github.repository
         env:
@@ -75,6 +86,6 @@ jobs:
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: thel-linux-x86_64
+          name: thel-linux-${{ steps.build.outputs.arch }}
           path: ${{ steps.build.outputs.tarball }}
           retention-days: 14

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -1,7 +1,8 @@
 name: release-linux
 
-# Manually build thel and attach the Linux binary (a portable tar.xz) to an
-# existing draft release, identified by its title (the version, e.g. v0.1.0-beta).
+# Manually build thel and attach the Linux binaries (a portable tar.xz per
+# architecture) to an existing draft release, identified by its title (the
+# version, e.g. v0.1.0-beta).
 # macOS has its own workflow (release-macos) so the two can be cut independently.
 # Uses the built-in GITHUB_TOKEN via the permissions below, so no token or secret
 # needs to be set up.
@@ -18,7 +19,11 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    # One native runner per architecture; no cross-compiling.
+    strategy:
+      matrix:
+        runner: [ubuntu-latest, ubuntu-24.04-arm]
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@c915c33a16f01166c17c4e35fe1d4085a2d71adb # v4
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,7 +1,7 @@
 # Installing thel
 
-thel is beta. It runs on Linux (x86_64) and macOS (Apple silicon). Windows is a
-goal but untested.
+thel is beta. It runs on Linux (x86_64 and aarch64) and macOS (Apple silicon).
+Windows is a goal but untested.
 
 ## macOS
 
@@ -42,13 +42,14 @@ brew install --cask joaquimrocha/tap/thel
 
 ### Direct download
 
-Download `thel-<version>-linux-x86_64.tar.xz` from the
+Download `thel-<version>-linux-<arch>.tar.xz` for your architecture (`x86_64`
+or `aarch64`) from the
 [latest release](https://github.com/joaquimrocha/thel/releases/latest) and
 unpack it. It contains a single self-contained `thel` binary, so put it
 anywhere on your `PATH`:
 
 ```sh
-tar -xf thel-*-linux-x86_64.tar.xz
+tar -xf thel-*-linux-$(uname -m).tar.xz
 install -Dm755 thel ~/.local/bin/thel
 ```
 


### PR DESCRIPTION
The Linux release workflow only ever ran on an x86_64 runner, so people on aarch64 machines had no artifact to download and were left compiling thel themselves for every release. So these changes matrix the workflow over a native runner per architecture, ubuntu-latest and ubuntu-24.04-arm, and attach both tarballs to the same draft release.

The tarball name now takes its architecture from uname -m rather than the hardcoded x86_64, which is correct precisely because every build is native and nothing here cross-compiles. The per-pull-request build stays x86_64 only: it exists to catch build breakage and report binary size, and neither needs doing twice.

Fixes #5 
cc/ @vrutkovs